### PR TITLE
Address review feedback for Deleverage updates

### DIFF
--- a/contracts/core/AuctionHouse.vy
+++ b/contracts/core/AuctionHouse.vy
@@ -84,6 +84,9 @@ interface VaultRegistry:
 interface AddressRegistry:
     def getAddr(_vaultId: uint256) -> address: view
 
+interface UnderscoreVault:
+    def convertToAssetsSafe(_shares: uint256) -> uint256: view
+
 struct AuctionBuyConfig:
     canBuyInAuctionGeneral: bool
     canBuyInAuctionAsset: bool
@@ -1187,9 +1190,17 @@ def withdrawTokensFromVault(
     _amount: uint256,
     _recipient: address,
     _vaultAddr: address,
+    _preflightSafeConversion: bool,
     _a: addys.Addys,
 ) -> (uint256, bool):
     assert msg.sender == addys._getDeleverageAddr() # dev: only deleverage allowed
+    if _preflightSafeConversion:
+        # Use the balance the vault can debit, not the larger requested amount.
+        # If the vault still sends less and that smaller amount converts to zero,
+        # Deleverage's retained post-withdraw invariant assertion will revert.
+        withdrawableAmount: uint256 = min(_amount, staticcall Vault(_vaultAddr).getTotalAmountForUser(_user, _asset))
+        if staticcall UnderscoreVault(_asset).convertToAssetsSafe(withdrawableAmount) == 0:
+            return 0, False
     return extcall Vault(_vaultAddr).withdrawTokensFromVault(_user, _asset, _amount, _recipient, _a)
 
 

--- a/contracts/core/Deleverage.vy
+++ b/contracts/core/Deleverage.vy
@@ -3,6 +3,9 @@
 
 # @version 0.4.3
 #pragma optimize codesize
+# At this source revision, the deployed runtime is 24,553 bytes including
+# Vyper's 96-byte immutables section: 23 bytes of EIP-170 headroom.
+# Re-measure the actual deployed code before making any runtime-affecting change.
 
 implements: Department
 
@@ -58,7 +61,7 @@ interface Registry:
     def isValidAddr(_addr: address) -> bool: view
 
 interface AuctionHouse:
-    def withdrawTokensFromVault(_user: address, _asset: address, _amount: uint256, _recipient: address, _vaultAddr: address, _a: addys.Addys) -> (uint256, bool): nonpayable
+    def withdrawTokensFromVault(_user: address, _asset: address, _amount: uint256, _recipient: address, _vaultAddr: address, _preflightSafeConversion: bool, _a: addys.Addys) -> (uint256, bool): nonpayable
 
 interface UnderscoreVault:
     def convertToAssetsSafe(_shares: uint256) -> uint256: view
@@ -195,7 +198,7 @@ vaultAddrs: transient(HashMap[uint256, address]) # vaultId -> vaultAddr
 assetLiqConfig: transient(HashMap[address, AssetLiqConfig]) # asset -> config
 didHandleAsset: transient(HashMap[address, HashMap[uint256, HashMap[address, bool]]]) # user -> vaultId -> asset -> did handle
 didHandleVaultId: transient(HashMap[address, HashMap[uint256, bool]]) # user -> vaultId -> did handle
-underscoreVaultRegistry: transient(address)
+underscoreVaultRegistry: transient(HashMap[address, address])
 
 UNDERSCORE_LEGOBOOK_ID: constant(uint256) = 3
 UNDERSCORE_VAULT_REGISTRY_ID: constant(uint256) = 10
@@ -262,11 +265,12 @@ def deleverageUser(_user: address, _caller: address, _targetRepayAmount: uint256
     assert not deptBasics.isPaused # dev: contract paused
     a: addys.Addys = addys._getAddys(_a)
     config: GenLiqConfig = staticcall MissionControl(a.missionControl).getGenLiqConfig()
-    underscoreCallerType: uint256 = self._getUnderscoreCallerType(_caller, a.missionControl)
-    isTrusted: bool = addys._isValidRipeAddr(_caller) or underscoreCallerType != 0
+    isTrusted: bool = addys._isValidRipeAddr(_caller)
+    if not isTrusted:
+        isTrusted = self._getUnderscoreAddrType(_caller, a.missionControl, False) != 0
     endaomentPsm: address = addys._getEndaomentPsmAddr()
     psmYieldPositionToken: address = staticcall EndaomentPSM(endaomentPsm).getUsdcYieldPositionVaultToken()
-    repaidAmount: uint256 = self._deleverageUser(_user, _caller, isTrusted, underscoreCallerType == UNDERSCORE_EARN_VAULT_CALLER_TYPE, _targetRepayAmount, config, addys._getEndaomentFundsAddr(), endaomentPsm, psmYieldPositionToken, a)
+    repaidAmount: uint256 = self._deleverageUser(_user, _caller, isTrusted, _targetRepayAmount, config, addys._getEndaomentFundsAddr(), endaomentPsm, psmYieldPositionToken, a)
     assert repaidAmount != 0 # dev: cannot deleverage
     return repaidAmount
 
@@ -280,8 +284,9 @@ def deleverageManyUsers(_users: DynArray[DeleverageUserRequest, MAX_DELEVERAGE_U
     assert not deptBasics.isPaused # dev: contract paused
     a: addys.Addys = addys._getAddys(_a)
     config: GenLiqConfig = staticcall MissionControl(a.missionControl).getGenLiqConfig()
-    underscoreCallerType: uint256 = self._getUnderscoreCallerType(_caller, a.missionControl)
-    isTrusted: bool = addys._isValidRipeAddr(_caller) or underscoreCallerType != 0
+    isTrusted: bool = addys._isValidRipeAddr(_caller)
+    if not isTrusted:
+        isTrusted = self._getUnderscoreAddrType(_caller, a.missionControl, False) != 0
 
     endaoFunds: address = addys._getEndaomentFundsAddr()
     endaomentPsm: address = addys._getEndaomentPsmAddr()
@@ -290,7 +295,7 @@ def deleverageManyUsers(_users: DynArray[DeleverageUserRequest, MAX_DELEVERAGE_U
     totalRepaidAmount: uint256 = 0
     numUsers: uint256 = 0
     for u: DeleverageUserRequest in _users:
-        repaidAmount: uint256 = self._deleverageUser(u.user, _caller, isTrusted, underscoreCallerType == UNDERSCORE_EARN_VAULT_CALLER_TYPE, u.targetRepayAmount, config, endaoFunds, endaomentPsm, psmYieldPositionToken, a)
+        repaidAmount: uint256 = self._deleverageUser(u.user, _caller, isTrusted, u.targetRepayAmount, config, endaoFunds, endaomentPsm, psmYieldPositionToken, a)
         if repaidAmount != 0:
             totalRepaidAmount += repaidAmount
             numUsers += 1
@@ -307,8 +312,9 @@ def deleverageWithSpecificAssets(_user: address, _assets: DynArray[DeleverageAss
     assert msg.sender == addys._getTellerAddr() # dev: only teller allowed
     assert not deptBasics.isPaused # dev: contract paused
     a: addys.Addys = addys._getAddys(_a)
-    underscoreCallerType: uint256 = self._getUnderscoreCallerType(_caller, a.missionControl)
-    isTrusted: bool = _user == _caller or addys._isValidRipeAddr(_caller) or underscoreCallerType != 0
+    isTrusted: bool = _user == _caller or addys._isValidRipeAddr(_caller)
+    if not isTrusted:
+        isTrusted = self._getUnderscoreAddrType(_caller, a.missionControl, False) != 0
 
     endaoFunds: address = addys._getEndaomentFundsAddr()
     endaomentPsm: address = addys._getEndaomentPsmAddr()
@@ -334,6 +340,7 @@ def deleverageWithSpecificAssets(_user: address, _assets: DynArray[DeleverageAss
     maxTargetRepayAmount: uint256 = userDebt.amount
     targetRepayAmount: uint256 = 0
     effectiveBuffer: uint256 = 0
+    useFullPayoffExtras: bool = False
 
     # process each asset in the specified order
     for data: DeleverageAsset in _assets:
@@ -357,13 +364,21 @@ def deleverageWithSpecificAssets(_user: address, _assets: DynArray[DeleverageAss
         repayForAsset: uint256 = min(maxTargetRepayAmount, data.targetRepayAmount)
         if targetRepayAmount != userDebt.amount:
             targetRepayAmount = unsafe_add(targetRepayAmount, min(unsafe_sub(userDebt.amount, targetRepayAmount), data.targetRepayAmount))
-            if underscoreCallerType != UNDERSCORE_EARN_VAULT_CALLER_TYPE and targetRepayAmount == userDebt.amount:
+            if targetRepayAmount == userDebt.amount:
+                # Owner-keyed full-payoff classification necessarily depends on
+                # the configured Underscore registry being healthy even when all
+                # payoff extras are zero. Governance can set that registry to
+                # zero to restore Ripe-only operation.
+                useFullPayoffExtras = self._getUnderscoreAddrType(_user, a.missionControl, False) != UNDERSCORE_EARN_VAULT_CALLER_TYPE
+            if useFullPayoffExtras:
                 # Full-payoff intent lets the buffer exceed this asset's target.
                 # If this asset cannot fill it, the extra budget carries to later assets.
                 effectiveBuffer = self._getFullPayoffBuffer(userDebt.amount)
                 maxTargetRepayAmount = unsafe_add(maxTargetRepayAmount, effectiveBuffer)
                 repayForAsset = unsafe_add(repayForAsset, effectiveBuffer)
         remainingToRepayForAsset: uint256 = self._handleSpecificAsset(_user, data.vaultId, vaultAddr, data.asset, repayForAsset, False, endaoFunds, endaomentPsm, psmYieldPositionToken, a)
+        # _handleSpecificAsset returns its budget unchanged or reduced, so the
+        # paired unsafe subtraction remains bounded by repayForAsset.
         paidAmountForAsset: uint256 = unsafe_sub(repayForAsset, remainingToRepayForAsset)
         maxTargetRepayAmount = unsafe_sub(maxTargetRepayAmount, paidAmountForAsset)
 
@@ -373,7 +388,7 @@ def deleverageWithSpecificAssets(_user: address, _assets: DynArray[DeleverageAss
 
     # Repay debt. This repeats the full-payoff check from the buffer branch above;
     # it relies on targetRepayAmount only moving up toward userDebt.amount in the loop.
-    debtToClear: uint256 = self._getDebtToClear(underscoreCallerType != UNDERSCORE_EARN_VAULT_CALLER_TYPE and targetRepayAmount == userDebt.amount, totalRepaidAmount, userDebt.amount)
+    debtToClear: uint256 = self._getDebtToClear(useFullPayoffExtras, totalRepaidAmount, userDebt.amount)
     hasGoodDebtHealth: bool = extcall CreditEngine(a.creditEngine).repayFromDept(_user, userDebt, debtToClear, newInterest, 0, a)
 
     log DeleverageUser(
@@ -498,6 +513,7 @@ def swapCollateral(
         _withdrawAmount,
         msg.sender, # recipient is governance
         withdrawVaultAddr,
+        False,
         a,
     )
     assert withdrawnAmount != 0 # dev: no collateral withdrawn
@@ -543,9 +559,8 @@ def deleverageForWithdrawal(_user: address, _vaultId: uint256, _asset: address, 
     assert not deptBasics.isPaused # dev: contract paused
     a: addys.Addys = addys._getAddys()
 
-    underscoreCallerType: uint256 = self._getUnderscoreCallerType(msg.sender, a.missionControl)
-    if underscoreCallerType == 0:
-        assert addys._isValidRipeAddr(msg.sender) # dev: no perms
+    if not addys._isValidRipeAddr(msg.sender):
+        assert self._getUnderscoreAddrType(msg.sender, a.missionControl, False) != 0 # dev: no perms
 
     # get current user state
     userDebt: UserDebt = empty(UserDebt)
@@ -641,7 +656,7 @@ def deleverageForWithdrawal(_user: address, _vaultId: uint256, _asset: address, 
     config: GenLiqConfig = staticcall MissionControl(a.missionControl).getGenLiqConfig()
     endaomentPsm: address = addys._getEndaomentPsmAddr()
     psmYieldPositionToken: address = staticcall EndaomentPSM(endaomentPsm).getUsdcYieldPositionVaultToken()
-    repaidAmount: uint256 = self._deleverageUser(_user, msg.sender, True, underscoreCallerType == UNDERSCORE_EARN_VAULT_CALLER_TYPE, requiredRepayment, config, addys._getEndaomentFundsAddr(), endaomentPsm, psmYieldPositionToken, a)
+    repaidAmount: uint256 = self._deleverageUser(_user, msg.sender, True, requiredRepayment, config, addys._getEndaomentFundsAddr(), endaomentPsm, psmYieldPositionToken, a)
     if repaidAmount != 0:
         self.lastDeleverageBlock[_user] = block.number
     return repaidAmount != 0
@@ -657,7 +672,6 @@ def _deleverageUser(
     _user: address,
     _caller: address,
     _isTrusted: bool,
-    _isUnderscoreEarnVaultCaller: bool,
     _targetRepayAmount: uint256,
     _config: GenLiqConfig,
     _endaoFunds: address,
@@ -671,7 +685,7 @@ def _deleverageUser(
     if not isTrusted and _user != _caller:
         delegation: cs.ActionDelegation = staticcall MissionControl(_a.missionControl).userDelegation(_user, _caller)
         isTrusted = delegation.canBorrow
-    
+
     # get latest user debt
     userDebt: UserDebt = empty(UserDebt)
     bt: UserBorrowTerms = empty(UserBorrowTerms)
@@ -689,6 +703,8 @@ def _deleverageUser(
     if not isTrusted:
         if not self._canDeleverageUserDebtPosition(userDebt.amount, bt.collateralVal, bt.debtTerms.redemptionThreshold):
             return 0
+        # SwitchboardBravo rejects ltv > redemptionThreshold. This ordering is
+        # required for the cap below to remain conservative.
         targetLtv: uint256 = bt.lowestLtv
         ltvPaybackBuffer: uint256 = staticcall MissionControl(_a.missionControl).getLtvPaybackBuffer()
         if ltvPaybackBuffer != 0:
@@ -698,8 +714,15 @@ def _deleverageUser(
             return 0
         targetRepayAmount = min(targetRepayAmount, maxRepayableAmount)
 
-    # do extras if not an underscore earn vault caller and target debt amount is full debt
-    useFullPayoffExtras: bool = not _isUnderscoreEarnVaultCaller and targetRepayAmount == userDebt.amount
+    # Earn vault position owners must not have more collateral removed than debt,
+    # regardless of which trusted caller initiated the deleverage.
+    useFullPayoffExtras: bool = targetRepayAmount == userDebt.amount
+    if useFullPayoffExtras:
+        # Owner-keyed full-payoff classification necessarily depends on the
+        # configured Underscore registry being healthy even when all payoff
+        # extras are zero. Governance can set that registry to zero to restore
+        # Ripe-only operation.
+        useFullPayoffExtras = self._getUnderscoreAddrType(_user, _a.missionControl, False) != UNDERSCORE_EARN_VAULT_CALLER_TYPE
 
     # get extra collateral if buffer params set (either usd value or bps over debt amount)
     effectiveBuffer: uint256 = 0
@@ -752,6 +775,9 @@ def _getDebtToClear(_useFullPayoffExtras: bool, _collateralValueRepaid: uint256,
     # while still removing floor-rounding dust within the configured caps.
     if _useFullPayoffExtras and _collateralValueRepaid != 0 and debtToClear < _debtAmount:
         dustRemaining: uint256 = unsafe_sub(_debtAmount, debtToClear)
+        # This is an explicit debt write-off: repayFromDept does not burn GREEN
+        # for the forgiven remainder. Deployment keeps both dust params at zero
+        # until governance approves the accounting policy.
         if dustRemaining <= self.deleverageDustThreshold and unsafe_mul(dustRemaining, HUNDRED_PERCENT) <= unsafe_mul(_debtAmount, self.deleverageDustBps):
             debtToClear = _debtAmount
     return debtToClear
@@ -1075,6 +1101,8 @@ def _getDeleverageInfo(_user: address, _a: addys.Addys) -> (uint256, uint256):
 
             # get asset LTV for weighted calculation
             debtTerms: cs.DebtTerms = staticcall MissionControl(_a.missionControl).getDebtTerms(asset)
+            # Zero-LTV assets remain repayment liquidity even though they do not
+            # contribute borrowing capacity in CreditEngine collateral value.
             ltvSum += usdValue * debtTerms.ltv
 
     # calculate effective weighted LTV
@@ -1135,7 +1163,7 @@ def _calcAmountToPay(_debtAmount: uint256, _collateralValue: uint256, _targetLtv
 def _canDeleverageUserDebtPosition(_userDebtAmount: uint256, _collateralVal: uint256, _redemptionThreshold: uint256) -> bool:
     if _redemptionThreshold == 0:
         return False
-    
+
     # check if collateral value is below (or equal) to redemption threshold
     redemptionThreshold: uint256 = _userDebtAmount * HUNDRED_PERCENT // _redemptionThreshold
     return _collateralVal <= redemptionThreshold
@@ -1153,7 +1181,7 @@ def _transferCollateral(
     _targetUsdValue: uint256,
     _a: addys.Addys,
 ) -> (uint256, uint256, bool):
-    isUnderscoreBasicEarnVault: bool = self._isUnderscoreBasicEarnVault(_asset, _a.missionControl)
+    isUnderscoreBasicEarnVault: bool = self._getUnderscoreAddrType(_asset, _a.missionControl, True) != 0
     underlyingAsset: address = empty(address)
     if isUnderscoreBasicEarnVault:
         underlyingAsset = staticcall IERC4626(_asset).asset()
@@ -1166,7 +1194,7 @@ def _transferCollateral(
     # withdraw and transfer to recipient -- AuctionHouse has permissions to perform this
     amountSent: uint256 = 0
     isPositionDepleted: bool = False
-    amountSent, isPositionDepleted = extcall AuctionHouse(_a.auctionHouse).withdrawTokensFromVault(_fromUser, _asset, maxAssetAmount, _toUser, _vaultAddr, _a)
+    amountSent, isPositionDepleted = extcall AuctionHouse(_a.auctionHouse).withdrawTokensFromVault(_fromUser, _asset, maxAssetAmount, _toUser, _vaultAddr, isUnderscoreBasicEarnVault, _a)
 
     usdValue: uint256 = _targetUsdValue * amountSent // maxAssetAmount
 
@@ -1186,8 +1214,10 @@ def _transferCollateral(
 
 
 @internal
-def _getUnderscoreCallerType(_addr: address, _mc: address) -> uint256:
-    # 0 = not underscore, 1 = underscore lego/other trusted caller, 2 = earn vault
+def _getUnderscoreAddrType(_addr: address, _mc: address, _basicEarnVaultOnly: bool) -> uint256:
+    # Normal mode classifies callers/owners: 0 = not Underscore, 1 = lego or
+    # other trusted caller, 2 = earn vault. Basic-vault-only mode classifies an
+    # asset and returns only 0 or 2; it deliberately skips the lego-book lookup.
     # Writes the underscore vault registry to transient cache, so do not use from @view paths.
     underscore: address = staticcall MissionControl(_mc).underscoreRegistry()
     if underscore == empty(address):
@@ -1195,8 +1225,12 @@ def _getUnderscoreCallerType(_addr: address, _mc: address) -> uint256:
 
     vaultRegistry: address = self._getUnderscoreVaultRegistry(underscore)
     if vaultRegistry != empty(address):
+        if _basicEarnVaultOnly:
+            return UNDERSCORE_EARN_VAULT_CALLER_TYPE if staticcall VaultRegistry(vaultRegistry).isBasicEarnVault(_addr) else 0
         if staticcall VaultRegistry(vaultRegistry).isEarnVault(_addr):
             return UNDERSCORE_EARN_VAULT_CALLER_TYPE
+    elif _basicEarnVaultOnly:
+        return 0
 
     # check if underscore lego
     undyLegoBook: address = staticcall Registry(underscore).getAddr(UNDERSCORE_LEGOBOOK_ID)
@@ -1206,23 +1240,12 @@ def _getUnderscoreCallerType(_addr: address, _mc: address) -> uint256:
 
 
 @internal
-def _isUnderscoreBasicEarnVault(_asset: address, _mc: address) -> bool:
-    underscoreRegistry: address = staticcall MissionControl(_mc).underscoreRegistry()
-    if underscoreRegistry == empty(address):
-        return False
-    vaultRegistry: address = self._getUnderscoreVaultRegistry(underscoreRegistry)
-    if vaultRegistry == empty(address):
-        return False
-    return staticcall VaultRegistry(vaultRegistry).isBasicEarnVault(_asset)
-
-
-@internal
 def _getUnderscoreVaultRegistry(_underscoreRegistry: address) -> address:
-    vaultRegistry: address = self.underscoreVaultRegistry
+    vaultRegistry: address = self.underscoreVaultRegistry[_underscoreRegistry]
     if vaultRegistry == empty(address):
         vaultRegistry = staticcall Registry(_underscoreRegistry).getAddr(UNDERSCORE_VAULT_REGISTRY_ID)
         if vaultRegistry != empty(address):
-            self.underscoreVaultRegistry = vaultRegistry
+            self.underscoreVaultRegistry[_underscoreRegistry] = vaultRegistry
     return vaultRegistry
 
 
@@ -1308,10 +1331,9 @@ def _getVaultAddr(_vaultId: uint256, _vaultBook: address) -> (address, bool):
 
 # deleverage params
 
-# Param ceilings are enforced in SwitchboardDelta after deployment to preserve
-# Deleverage runtime bytecode size. Constructor args are validated above.
-# WARNING: future switchboards with access to these setters must enforce the same caps,
-# or unsafe math in deleverage flows can overflow under malicious values.
+# Constructor args are validated above. The four legacy setters remain
+# Switchboard-enforced to preserve runtime bytecode; the new full-payoff params
+# also enforce their unsafe-math ceilings here as defense in depth.
 
 
 @external
@@ -1352,12 +1374,16 @@ def setDeleverageFullPayoffParam(_param: uint256, _amount: uint256):
     assert not deptBasics.isPaused # dev: contract paused
     # _param values: 1=fullPayoffBuffer, 2=overageBps, 3=dustThreshold, 4=dustBps
     if _param == 1:
+        assert _amount <= MAX_DELEVERAGE_FULL_PAYOFF_BUFFER # dev: exceeds hard ceiling
         self.deleverageFullPayoffBuffer = _amount
     elif _param == 2:
+        assert _amount <= MAX_DELEVERAGE_OVERAGE_BPS # dev: exceeds hard ceiling
         self.deleverageOverageBps = _amount
     elif _param == 3:
+        assert _amount <= MAX_DELEVERAGE_DUST_THRESHOLD # dev: exceeds hard ceiling
         self.deleverageDustThreshold = _amount
     else:
         assert _param == 4 # dev: invalid param
+        assert _amount <= MAX_DELEVERAGE_DUST_BPS # dev: exceeds hard ceiling
         self.deleverageDustBps = _amount
     log DeleverageFullPayoffParamSet(param=_param, amount=_amount)

--- a/contracts/mock/MockUndyV2.vy
+++ b/contracts/mock/MockUndyV2.vy
@@ -18,6 +18,7 @@ _isUserWallet: public(bool)
 _earnVaults: public(HashMap[address, bool])
 _basicEarnVaults: public(HashMap[address, bool])
 _allAddressesAreVaults: public(bool)
+_vaultCheckRevertAddress: public(address)
 
 
 @deploy
@@ -64,6 +65,7 @@ def setUseThisLegoId(_legoId: uint256):
 @view
 @external
 def isEarnVault(_vaultAddr: address) -> bool:
+    assert _vaultAddr != self._vaultCheckRevertAddress # dev: mock underscore vault check
     if self._allAddressesAreVaults:
         return True
     return self._earnVaults[_vaultAddr]
@@ -72,6 +74,7 @@ def isEarnVault(_vaultAddr: address) -> bool:
 @view
 @external
 def isBasicEarnVault(_vaultAddr: address) -> bool:
+    assert _vaultAddr != self._vaultCheckRevertAddress # dev: mock underscore vault check
     if self._allAddressesAreVaults:
         return True
     return self._basicEarnVaults[_vaultAddr]
@@ -92,6 +95,11 @@ def setBasicEarnVault(_vaultAddr: address, _isVault: bool):
 @external
 def setAllAddressesAreVaults(_allAreVaults: bool):
     self._allAddressesAreVaults = _allAreVaults
+
+
+@external
+def setVaultCheckRevertAddress(_addr: address):
+    self._vaultCheckRevertAddress = _addr
 
 
 #############

--- a/migrations/base-mainnet/2026072800_DeleverageAuctionHouse.py
+++ b/migrations/base-mainnet/2026072800_DeleverageAuctionHouse.py
@@ -1,0 +1,31 @@
+from scripts.utils import log
+from scripts.utils.migration import Migration
+
+
+# Before scheduling this migration, execute it through scripts/migrate.py on a
+# pinned Base-mainnet fork and retain the MigrationRunner log. Offline/static
+# constructor checks are not a substitute because the four legacy values below
+# are intentionally read from the live Deleverage deployment at execution time.
+def migrate(migration: Migration):
+    hq = migration.get_contract("RipeHq")
+    current_deleverage = migration.get_contract("Deleverage")
+
+    log.h1("Deploying Auction House with Underscore safe-conversion preflight")
+    migration.deploy(
+        "AuctionHouse",
+        hq,
+    )
+
+    log.h1("Deploying Deleverage with live legacy values and disabled payoff extras")
+    migration.deploy(
+        "Deleverage",
+        hq,
+        current_deleverage.minDeleverageBps(),
+        current_deleverage.deleverageBuffer(),
+        current_deleverage.deleverageCooldown(),
+        current_deleverage.underscoreSafeSpreadBps(),
+        0,  # full-payoff buffer: disabled pending governance policy approval
+        0,  # overage bps: disabled pending governance policy approval
+        0,  # dust threshold: disabled pending governance policy approval
+        0,  # dust bps: disabled pending governance policy approval
+    )

--- a/migrations/base-mainnet/2026072801_RedeploySBDeltaForDeleverage.py
+++ b/migrations/base-mainnet/2026072801_RedeploySBDeltaForDeleverage.py
@@ -1,0 +1,23 @@
+from scripts.utils import log
+from scripts.utils.migration import Migration
+
+
+# Before scheduling this migration, execute it through scripts/migrate.py on the
+# same pinned Base-mainnet fork as the preceding core-contract migration and
+# retain the MigrationRunner log with the review evidence.
+def migrate(migration: Migration):
+    hq = migration.get_contract("RipeHq")
+    blueprint = migration.blueprint()
+
+    # Keep this deployment separate from the core-contract migration so the
+    # governance surface and four new parameter ceilings receive their own review.
+    log.h1("Deploying Switchboard Delta for Deleverage configuration")
+    switchboard_delta = migration.deploy(
+        "SwitchboardDelta",
+        hq,
+        migration.account(),
+        blueprint.PARAMS["MIN_SWITCHBOARD_CHANGE_TIMELOCK"],
+        blueprint.PARAMS["MAX_SWITCHBOARD_CHANGE_TIMELOCK"],
+    )
+
+    migration.execute(switchboard_delta.relinquishGov)

--- a/scripts/abis/AuctionHouse.json
+++ b/scripts/abis/AuctionHouse.json
@@ -1645,6 +1645,10 @@
         "type": "address"
       },
       {
+        "name": "_preflightSafeConversion",
+        "type": "bool"
+      },
+      {
         "name": "_a",
         "type": "tuple",
         "components": [

--- a/scripts/abis/SwitchboardDelta.json
+++ b/scripts/abis/SwitchboardDelta.json
@@ -964,6 +964,278 @@
     "type": "event"
   },
   {
+    "name": "PendingMinDeleverageBpsChange",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "confirmationBlock",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "actionId",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "MinDeleverageBpsSet",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "PendingDeleverageBufferChange",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "confirmationBlock",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "actionId",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "DeleverageBufferSet",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "PendingDeleverageCooldownChange",
+    "inputs": [
+      {
+        "name": "blocks",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "confirmationBlock",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "actionId",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "DeleverageCooldownSet",
+    "inputs": [
+      {
+        "name": "blocks",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "PendingUnderscoreSafeSpreadBpsChange",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "confirmationBlock",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "actionId",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "UnderscoreSafeSpreadBpsSet",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "PendingDeleverageFullPayoffBufferChange",
+    "inputs": [
+      {
+        "name": "usdAmount",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "confirmationBlock",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "actionId",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "DeleverageFullPayoffBufferSet",
+    "inputs": [
+      {
+        "name": "usdAmount",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "PendingDeleverageOverageBpsChange",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "confirmationBlock",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "actionId",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "DeleverageOverageBpsSet",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "PendingDeleverageDustThresholdChange",
+    "inputs": [
+      {
+        "name": "usdAmount",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "confirmationBlock",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "actionId",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "DeleverageDustThresholdSet",
+    "inputs": [
+      {
+        "name": "usdAmount",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "PendingDeleverageDustBpsChange",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "confirmationBlock",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "actionId",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "DeleverageDustBpsSet",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
     "name": "GovChangeTimeLockModified",
     "inputs": [
       {
@@ -1723,6 +1995,142 @@
             "type": "uint256"
           }
         ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "setMinDeleverageBps",
+    "inputs": [
+      {
+        "name": "_bps",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "setDeleverageBuffer",
+    "inputs": [
+      {
+        "name": "_bps",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "setDeleverageFullPayoffBuffer",
+    "inputs": [
+      {
+        "name": "_usdAmount",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "setDeleverageOverageBps",
+    "inputs": [
+      {
+        "name": "_bps",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "setDeleverageDustThreshold",
+    "inputs": [
+      {
+        "name": "_usdAmount",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "setDeleverageDustBps",
+    "inputs": [
+      {
+        "name": "_bps",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "setDeleverageCooldown",
+    "inputs": [
+      {
+        "name": "_blocks",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "setUnderscoreSafeSpreadBps",
+    "inputs": [
+      {
+        "name": "_bps",
+        "type": "uint256"
       }
     ],
     "outputs": [
@@ -3027,6 +3435,142 @@
       {
         "name": "",
         "type": "bool"
+      }
+    ]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "pendingMinDeleverageBps",
+    "inputs": [
+      {
+        "name": "arg0",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "pendingDeleverageBuffer",
+    "inputs": [
+      {
+        "name": "arg0",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "pendingDeleverageCooldown",
+    "inputs": [
+      {
+        "name": "arg0",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "pendingUnderscoreSafeSpreadBps",
+    "inputs": [
+      {
+        "name": "arg0",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "pendingDeleverageFullPayoffBuffer",
+    "inputs": [
+      {
+        "name": "arg0",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "pendingDeleverageOverageBps",
+    "inputs": [
+      {
+        "name": "arg0",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "pendingDeleverageDustThreshold",
+    "inputs": [
+      {
+        "name": "arg0",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "pendingDeleverageDustBps",
+    "inputs": [
+      {
+        "name": "arg0",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
       }
     ]
   },

--- a/tests/conf_env.py
+++ b/tests/conf_env.py
@@ -15,7 +15,7 @@ FORKS = {
     "mainnet": {
         "rpc_url": f"https://eth-mainnet.g.alchemy.com/v2/{os.environ.get('WEB3_ALCHEMY_API_KEY')}",
         "etherscan_url": "https://api.etherscan.io/api",
-        "etherscan_api_key": os.environ["ETHERSCAN_API_KEY"],
+        "etherscan_api_key": os.environ.get("ETHERSCAN_API_KEY"),
         "block": 21552600,
         "anvil": True,
     },
@@ -23,7 +23,7 @@ FORKS = {
         "rpc_url": f"https://base-mainnet.g.alchemy.com/v2/{os.environ.get('WEB3_ALCHEMY_API_KEY')}",
         "block": 34471929,
         "etherscan_url": "https://api.etherscan.io/v2/api?chainid=8453",
-        "etherscan_api_key": os.environ["ETHERSCAN_API_KEY"],
+        "etherscan_api_key": os.environ.get("ETHERSCAN_API_KEY"),
         "anvil": True,
     }
 }
@@ -107,7 +107,9 @@ def set_etherscan(fork):
     api_key = config["etherscan_api_key"]
     uri = config["etherscan_url"]
 
-    boa.set_etherscan(api_key=api_key, uri=uri)
+    if fork in FORKS and not api_key:
+        pytest.fail("ETHERSCAN_API_KEY is required for remote fork tests")
+    boa.set_etherscan(api_key=api_key or "local-placeholder", uri=uri)
 
 
 @pytest.fixture(scope="session")

--- a/tests/core/deleverage/test_deleverage_for_withdrawal.py
+++ b/tests/core/deleverage/test_deleverage_for_withdrawal.py
@@ -413,6 +413,72 @@ def test_withdraw_cbbtc_with_sgreen_deleveragable(
     assert events[0].stabAsset == savings_green.address
 
 
+@pytest.mark.parametrize("is_earn_vault_owner", [False, True])
+def test_full_payoff_withdrawal_classifies_position_owner(
+    is_earn_vault_owner,
+    deleverage,
+    teller,
+    credit_engine,
+    simple_erc20_vault,
+    bob,
+    alpha_token,
+    alpha_token_whale,
+    charlie_token,
+    charlie_token_whale,
+    setupDeleverage,
+    performDeposit,
+    setup_priority_configs,
+    mission_control,
+    mock_undy_v2,
+    switchboard_alpha,
+):
+    """Withdrawal payoff extras depend on the owner, not the trusted Teller caller."""
+    mission_control.setUnderscoreRegistry(mock_undy_v2.address, sender=switchboard_alpha.address)
+    mock_undy_v2.setAllAddressesAreVaults(False)
+    mock_undy_v2.setEarnVault(bob, is_earn_vault_owner)
+    mock_undy_v2.setBasicEarnVault(bob, False)
+
+    deleverage.setDeleverageFullPayoffParam(1, 10**15, sender=switchboard_alpha.address)
+    deleverage.setDeleverageFullPayoffParam(2, 100, sender=switchboard_alpha.address)
+    deleverage.setDeleverageFullPayoffParam(3, 0, sender=switchboard_alpha.address)
+    deleverage.setDeleverageFullPayoffParam(4, 0, sender=switchboard_alpha.address)
+
+    setupDeleverage(
+        bob,
+        alpha_token,
+        alpha_token_whale,
+        deposit_amount=1_000 * EIGHTEEN_DECIMALS,
+        borrow_amount=700 * EIGHTEEN_DECIMALS,
+        get_sgreen=False,
+    )
+    performDeposit(
+        bob,
+        700 * SIX_DECIMALS,
+        charlie_token,
+        charlie_token_whale,
+        simple_erc20_vault,
+    )
+    setup_priority_configs(
+        priority_stab_assets=[],
+        priority_liq_assets=[(simple_erc20_vault, charlie_token)],
+    )
+
+    pre_debt = credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount
+    assert deleverage.deleverageForWithdrawal(
+        bob,
+        3,
+        alpha_token,
+        1_000 * EIGHTEEN_DECIMALS,
+        sender=teller.address,
+    )
+    assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == 0
+
+    deleverage_log = filter_logs(deleverage, "DeleverageUser")[-1]
+    expected_buffer = 0 if is_earn_vault_owner else 10**15
+    assert deleverage_log.targetRepayAmount == pre_debt
+    assert deleverage_log.targetRepayAmountWithBuffer == pre_debt + expected_buffer
+
+
 def test_withdraw_cbbtc_with_mixed_usdc_and_sgreen(
     deleverage,
     teller,

--- a/tests/core/deleverage/test_deleverage_permissions.py
+++ b/tests/core/deleverage/test_deleverage_permissions.py
@@ -1,6 +1,7 @@
 import pytest
 import boa
-from constants import EIGHTEEN_DECIMALS
+from constants import EIGHTEEN_DECIMALS, ZERO_ADDRESS
+from conf_utils import filter_logs
 
 HUNDRED_PERCENT = 100_00
 SIX_DECIMALS = 10**6
@@ -11,6 +12,7 @@ EIGHT_DECIMALS = 10**8
 def reset_undy_v2_mock(mock_undy_v2):
     yield
     mock_undy_v2.setAllAddressesAreVaults(True)
+    mock_undy_v2.setVaultCheckRevertAddress(ZERO_ADDRESS)
 
 
 @pytest.fixture
@@ -1650,10 +1652,12 @@ def test_deleverageManyUsers_trusted_no_caps(
     performDeposit,
     setup_redemption_zone,
     mock_price_source,
+    mission_control,
+    mock_undy_v2,
     _test,
 ):
     """
-    Test that trusted caller can fully deleverage all users in batch.
+    Test that batch payoff extras are classified per position owner.
     """
     # Setup both users in redemption zone
     initial_price, new_price = setup_redemption_zone(
@@ -1672,6 +1676,16 @@ def test_deleverageManyUsers_trusted_no_caps(
     # Drop price
     mock_price_source.setPrice(alpha_token, new_price)
 
+    mission_control.setUnderscoreRegistry(mock_undy_v2.address, sender=switchboard_alpha.address)
+    mock_undy_v2.setAllAddressesAreVaults(False)
+    mock_undy_v2.setEarnVault(bob, True)
+    mock_undy_v2.setBasicEarnVault(bob, False)
+    mock_undy_v2.setEarnVault(alice, False)
+    mock_undy_v2.setBasicEarnVault(alice, False)
+
+    bob_pre_debt = credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount
+    alice_pre_debt = credit_engine.getLatestUserDebtAndTerms(alice, False)[0].amount
+
     # Teller (trusted) batch deleverages
     users = [(bob, 0), (alice, 0)]
     total_repaid = teller.deleverageManyUsers(users, sender=switchboard_alpha.address)
@@ -1682,6 +1696,13 @@ def test_deleverageManyUsers_trusted_no_caps(
 
     _test(bob_debt, 0)
     _test(alice_debt, 0)
+    assert total_repaid == bob_pre_debt + alice_pre_debt
+
+    logs = filter_logs(teller, "DeleverageUser")[-2:]
+    logs_by_user = {log.user: log for log in logs}
+    expected_alice_overage = min(10**15, alice_pre_debt * 100 // HUNDRED_PERCENT)
+    assert logs_by_user[bob].targetRepayAmountWithBuffer == bob_pre_debt
+    assert logs_by_user[alice].targetRepayAmountWithBuffer == alice_pre_debt + expected_alice_overage
 
 
 ###############################################################################
@@ -1691,6 +1712,105 @@ def test_deleverageManyUsers_trusted_no_caps(
 # isBasicEarnVault() in _isUnderscoreEarnVaultWithRegistry(), breaking
 # permission checks for leveraged/amplified vaults.
 ###############################################################################
+
+
+def test_local_trust_checks_do_not_depend_on_underscore_registry_health(
+    ripe_hq,
+    switchboard,
+    switchboard_alpha,
+    teller,
+    deleverage,
+    credit_engine,
+    alpha_token,
+    bob,
+    mission_control,
+    mock_undy_v2,
+):
+    """Locally trusted Ripe callers must short-circuit Underscore permission checks."""
+    assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == 0
+    assert ripe_hq.isValidAddr(teller.address)
+    assert ripe_hq.isValidAddr(deleverage.address)
+    mission_control.setUnderscoreRegistry(mock_undy_v2.address, sender=switchboard_alpha.address)
+    mock_undy_v2.setAllAddressesAreVaults(False)
+    mock_undy_v2.setVaultCheckRevertAddress(teller.address)
+
+    with boa.reverts("cannot deleverage"):
+        teller.deleverageUser(bob, 1, sender=teller.address)
+
+    with boa.reverts("nobody deleveraged"):
+        teller.deleverageManyUsers([(bob, 1)], sender=teller.address)
+
+    assert teller.deleverageWithSpecificAssets([], bob, sender=teller.address) == 0
+    assert deleverage.deleverageForWithdrawal(
+        bob, 3, alpha_token, 1, sender=teller.address
+    ) is False
+
+
+def test_full_payoff_owner_classification_depends_on_registry_health(
+    switchboard_alpha,
+    teller,
+    credit_engine,
+    simple_erc20_vault,
+    alpha_token,
+    alpha_token_whale,
+    bob,
+    mission_control,
+    mock_undy_v2,
+    setupDeleverage,
+    setup_priority_configs,
+    setup_redemption_zone,
+):
+    """A broken registry blocks full-payoff classification and owner debt reads."""
+    setup_redemption_zone(
+        alpha_token,
+        alpha_token_whale,
+        bob,
+        1_000 * EIGHTEEN_DECIMALS,
+        500 * EIGHTEEN_DECIMALS,
+    )
+    setupDeleverage(
+        bob,
+        alpha_token,
+        alpha_token_whale,
+        get_sgreen=False,
+    )
+    setup_priority_configs(
+        priority_liq_assets=[(simple_erc20_vault, alpha_token)]
+    )
+
+    pre_debt = credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount
+    pre_collateral = simple_erc20_vault.getTotalAmountForUser(bob, alpha_token)
+
+    mission_control.setUnderscoreRegistry(
+        mock_undy_v2.address,
+        sender=switchboard_alpha.address,
+    )
+    mock_undy_v2.setAllAddressesAreVaults(False)
+    mock_undy_v2.setVaultCheckRevertAddress(bob)
+
+    # The caller is locally trusted, but a full payoff still classifies the
+    # position owner so earn-vault owners never pay full-payoff extras.
+    with boa.reverts("mock underscore vault check"):
+        teller.deleverageUser(bob, 0, sender=switchboard_alpha.address)
+
+    # CreditEngine independently classifies Underscore owners on its read path,
+    # widening the configured registry's failure surface beyond Deleverage.
+    with boa.reverts("mock underscore vault check"):
+        credit_engine.getLatestUserDebtAndTerms(bob, False)
+
+    # Restore the mock before reading the unchanged position.
+    mock_undy_v2.setVaultCheckRevertAddress(ZERO_ADDRESS)
+    assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == pre_debt
+    assert simple_erc20_vault.getTotalAmountForUser(bob, alpha_token) == pre_collateral
+
+    # Governance's documented escape hatch removes the external dependency.
+    mock_undy_v2.setVaultCheckRevertAddress(bob)
+    mission_control.setUnderscoreRegistry(
+        ZERO_ADDRESS,
+        sender=switchboard_alpha.address,
+    )
+    assert teller.deleverageUser(bob, 0, sender=switchboard_alpha.address) > 0
+    assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == 0
 
 
 def test_leveraged_underscore_vault_passes_deleverageForWithdrawal_permission(

--- a/tests/core/deleverage/test_deleverage_phase2.py
+++ b/tests/core/deleverage/test_deleverage_phase2.py
@@ -1,6 +1,6 @@
 import pytest
 import boa
-from constants import EIGHTEEN_DECIMALS
+from constants import EIGHTEEN_DECIMALS, ZERO_ADDRESS
 from conf_utils import filter_logs
 
 SIX_DECIMALS = 10**6  # For tokens like USDC/Charlie that have 6 decimals
@@ -87,6 +87,7 @@ def setup(
     yield
 
     mock_undy_v2.setAllAddressesAreVaults(True)
+    mock_undy_v2.setVaultCheckRevertAddress(ZERO_ADDRESS)
     alpha_token_vault_with_safe_gap.setSafeDiscountBps(500)
 
 
@@ -2297,10 +2298,11 @@ def test_phase2_underscore_earn_vault_safe_zero_does_not_overcredit(
     assert alpha_token_vault_with_safe_gap.balanceOf(endaoment_funds) == pre_endaoment_shares
 
 
-def test_phase2_underscore_earn_vault_dust_amount_safe_zero_reverts(
+def test_phase2_underscore_earn_vault_dust_amount_safe_zero_skips_before_withdrawal(
     ripe_hq,  # Ensures switchboard is registered
     switchboard,  # Ensures switchboard_alpha is registered
     teller,
+    credit_engine,
     simple_erc20_vault,
     bob,
     alpha_token,
@@ -2319,7 +2321,7 @@ def test_phase2_underscore_earn_vault_dust_amount_safe_zero_reverts(
 ):
     """
     Sample-size safe conversion can pass while a depleted dust position converts
-    to zero safely. That must revert instead of crediting fallback USD value.
+    to zero safely. The asset must be skipped before withdrawal.
     """
     mission_control.setUnderscoreRegistry(mock_undy_v2.address, sender=switchboard_alpha.address)
     mock_undy_v2.setAllAddressesAreVaults(False)
@@ -2380,11 +2382,138 @@ def test_phase2_underscore_earn_vault_dust_amount_safe_zero_reverts(
         priority_liq_assets=[(simple_erc20_vault, alpha_token_vault_with_safe_gap)],
     )
 
-    with boa.reverts("zero safe underlying"):
+    with boa.reverts("cannot deleverage"):
         teller.deleverageUser(bob, 10 * EIGHTEEN_DECIMALS, sender=switchboard_alpha.address)
 
     assert simple_erc20_vault.getTotalAmountForUser(bob, alpha_token_vault_with_safe_gap) == pre_vault_shares
     assert alpha_token_vault_with_safe_gap.balanceOf(endaoment_funds) == pre_endaoment_shares
+
+    # A healthy asset later in the same ordering must still be processed.
+    setAssetConfig(
+        alpha_token,
+        _vaultIds=[3],
+        _debtTerms=debt_terms,
+        _shouldBurnAsPayment=False,
+        _shouldTransferToEndaoment=True,
+    )
+    setup_priority_configs(
+        priority_stab_assets=[],
+        priority_liq_assets=[
+            (simple_erc20_vault, alpha_token_vault_with_safe_gap),
+            (simple_erc20_vault, alpha_token),
+        ],
+    )
+    target_repay = 10 * EIGHTEEN_DECIMALS
+    pre_debt = credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount
+    repaid = teller.deleverageUser(bob, target_repay, sender=switchboard_alpha.address)
+
+    assert repaid == target_repay
+    assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == pre_debt - target_repay
+    assert simple_erc20_vault.getTotalAmountForUser(bob, alpha_token_vault_with_safe_gap) == pre_vault_shares
+    assert alpha_token_vault_with_safe_gap.balanceOf(endaoment_funds) == pre_endaoment_shares
+
+
+def test_phase2_dust_user_does_not_revert_later_healthy_batch_user(
+    ripe_hq,
+    switchboard,
+    teller,
+    credit_engine,
+    simple_erc20_vault,
+    bob,
+    alice,
+    alpha_token,
+    alpha_token_whale,
+    bravo_token,
+    bravo_token_whale,
+    alpha_token_vault_with_safe_gap,
+    performDeposit,
+    setupDeleverage,
+    setup_priority_configs,
+    setAssetConfig,
+    createDebtTerms,
+    mock_price_source,
+    mission_control,
+    mock_undy_v2,
+    endaoment_funds,
+    switchboard_alpha,
+):
+    """A soft-skipped dust user must not atomically roll back a later user."""
+    mission_control.setUnderscoreRegistry(mock_undy_v2.address, sender=switchboard_alpha.address)
+    mock_undy_v2.setAllAddressesAreVaults(False)
+    mock_undy_v2.setEarnVault(alpha_token_vault_with_safe_gap.address, True)
+    mock_undy_v2.setBasicEarnVault(alpha_token_vault_with_safe_gap.address, True)
+    alpha_token_vault_with_safe_gap.setSafeDiscountBps(9999)
+
+    debt_terms = createDebtTerms(
+        _ltv=80_00,
+        _redemptionThreshold=85_00,
+        _liqThreshold=90_00,
+        _liqFee=5_00,
+        _borrowRate=0,
+    )
+    setAssetConfig(
+        alpha_token_vault_with_safe_gap,
+        _vaultIds=[3],
+        _debtTerms=debt_terms,
+        _shouldBurnAsPayment=False,
+        _shouldTransferToEndaoment=True,
+    )
+    setAssetConfig(
+        alpha_token,
+        _vaultIds=[3],
+        _debtTerms=debt_terms,
+        _shouldBurnAsPayment=False,
+        _shouldTransferToEndaoment=False,
+    )
+
+    setupDeleverage(
+        bob,
+        alpha_token,
+        alpha_token_whale,
+        deposit_amount=1_000 * EIGHTEEN_DECIMALS,
+        borrow_amount=20 * EIGHTEEN_DECIMALS,
+        get_sgreen=False,
+    )
+    setupDeleverage(
+        alice,
+        bravo_token,
+        bravo_token_whale,
+        deposit_amount=1_000 * EIGHTEEN_DECIMALS,
+        borrow_amount=20 * EIGHTEEN_DECIMALS,
+        get_sgreen=False,
+    )
+
+    alpha_token.transfer(bob, 100 * EIGHTEEN_DECIMALS, sender=alpha_token_whale)
+    alpha_token.approve(alpha_token_vault_with_safe_gap, 100 * EIGHTEEN_DECIMALS, sender=bob)
+    alpha_token_vault_with_safe_gap.deposit(100 * EIGHTEEN_DECIMALS, bob, sender=bob)
+    alpha_token.transfer(alpha_token_vault_with_safe_gap, 100 * EIGHTEEN_DECIMALS, sender=alpha_token_whale)
+    assert alpha_token_vault_with_safe_gap.convertToAssetsSafe(1) == 0
+    performDeposit(bob, 1, alpha_token_vault_with_safe_gap, bob, simple_erc20_vault)
+
+    setup_priority_configs(
+        priority_stab_assets=[],
+        priority_liq_assets=[
+            (simple_erc20_vault, alpha_token_vault_with_safe_gap),
+            (simple_erc20_vault, bravo_token),
+        ],
+    )
+
+    bob_pre_debt = credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount
+    alice_pre_debt = credit_engine.getLatestUserDebtAndTerms(alice, False)[0].amount
+    pre_bob_dust = simple_erc20_vault.getTotalAmountForUser(bob, alpha_token_vault_with_safe_gap)
+    pre_endaoment_dust = alpha_token_vault_with_safe_gap.balanceOf(endaoment_funds)
+    target = 10 * EIGHTEEN_DECIMALS
+
+    total_repaid = teller.deleverageManyUsers(
+        [(bob, target), (alice, target)],
+        sender=switchboard_alpha.address,
+    )
+
+    assert total_repaid == target
+    assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == bob_pre_debt
+    assert credit_engine.getLatestUserDebtAndTerms(alice, False)[0].amount == alice_pre_debt - target
+    assert simple_erc20_vault.getTotalAmountForUser(bob, alpha_token_vault_with_safe_gap) == pre_bob_dust
+    assert alpha_token_vault_with_safe_gap.balanceOf(endaoment_funds) == pre_endaoment_dust
 
 
 def test_phase2_underscore_earn_vault_depleted_position_credits_from_amount_sent(
@@ -2535,6 +2664,17 @@ def _assert_deleverage_user_amounts(
     assert deleverage_log.debtToClear == debt_to_clear
 
 
+def test_actual_deployed_runtime_stays_under_eip170(deleverage, auction_house):
+    """Measure on-chain code, including the 96 bytes absent from compiler_data."""
+    deleverage_size = len(boa.env.get_code(deleverage.address))
+    auction_house_size = len(boa.env.get_code(auction_house.address))
+
+    assert deleverage_size == 24_553
+    assert auction_house_size == 24_389
+    assert deleverage_size <= 24_576
+    assert auction_house_size <= 24_576
+
+
 @pytest.mark.parametrize(
     "param_id,value,getter",
     [
@@ -2552,7 +2692,7 @@ def test_deleverage_full_payoff_cleanup_setters(
     value,
     getter,
 ):
-    """Full-payoff cleanup params live on Deleverage; Switchboard enforces caps."""
+    """New unsafe-math params retain caps in both Deleverage and Switchboard."""
     with boa.reverts("only switchboard allowed"):
         deleverage.setDeleverageFullPayoffParam(param_id, value, sender=bob)
 
@@ -2565,6 +2705,25 @@ def test_deleverage_full_payoff_cleanup_setters(
     assert logs[0].param == param_id
     assert logs[0].amount == value
     assert getattr(deleverage, getter)() == value
+
+
+@pytest.mark.parametrize(
+    "param_id,value",
+    [
+        (1, 10**18 + 1),
+        (2, 500 + 1),
+        (3, 10**16 + 1),
+        (4, 500 + 1),
+    ],
+)
+def test_deleverage_full_payoff_cleanup_setters_enforce_hard_ceilings(
+    deleverage,
+    switchboard_alpha,
+    param_id,
+    value,
+):
+    with boa.reverts("exceeds hard ceiling"):
+        deleverage.setDeleverageFullPayoffParam(param_id, value, sender=switchboard_alpha.address)
 
 
 @pytest.mark.parametrize("param_id", [0, 5])
@@ -3352,7 +3511,7 @@ def test_full_payoff_buffer_applies_to_admin_with_basic_underscore_collateral(
     mock_undy_v2.setAllAddressesAreVaults(True)
 
 
-def test_full_payoff_extras_disabled_for_underscore_earn_vault_caller(
+def test_full_payoff_extras_apply_for_ordinary_user_when_caller_is_earn_vault(
     ripe_hq,
     switchboard,
     teller,
@@ -3369,7 +3528,7 @@ def test_full_payoff_extras_disabled_for_underscore_earn_vault_caller(
     mock_undy_v2,
     switchboard_alpha,
 ):
-    """Any Underscore earn-vault caller keeps the old exact-debt collateral target."""
+    """Caller classification must not suppress extras for an ordinary user."""
     mission_control.setUnderscoreRegistry(mock_undy_v2.address, sender=switchboard_alpha.address)
     mock_undy_v2.setAllAddressesAreVaults(False)
     mock_undy_v2.setEarnVault(alice, True)
@@ -3379,62 +3538,6 @@ def test_full_payoff_extras_disabled_for_underscore_earn_vault_caller(
     deleverage.setDeleverageFullPayoffParam(2, 100, sender=switchboard_alpha.address)
     deleverage.setDeleverageFullPayoffParam(3, 10**15, sender=switchboard_alpha.address)
     deleverage.setDeleverageFullPayoffParam(4, 100, sender=switchboard_alpha.address)
-
-    setupDeleverage(
-        bob,
-        alpha_token,
-        alpha_token_whale,
-        deposit_amount=1_000 * EIGHTEEN_DECIMALS,
-        borrow_amount=500 * EIGHTEEN_DECIMALS,
-        get_sgreen=False,
-    )
-    setup_priority_configs(
-        priority_stab_assets=[],
-        priority_liq_assets=[(simple_erc20_vault, alpha_token)],
-    )
-
-    pre_debt = credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount
-
-    repaid_amount = teller.deleverageUser(bob, 0, sender=alice)
-
-    assert repaid_amount == pre_debt
-    assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == 0
-
-    transfer_log = filter_logs(teller, "EndaomentTransferDuringDeleverage")[-1]
-    deleverage_log = filter_logs(teller, "DeleverageUser")[-1]
-    assert transfer_log.usdValue == pre_debt
-    _assert_deleverage_user_amounts(deleverage_log, pre_debt, pre_debt, pre_debt, pre_debt)
-
-    mock_undy_v2.setAllAddressesAreVaults(True)
-
-
-def test_full_payoff_extras_apply_for_underscore_non_earn_caller(
-    ripe_hq,
-    switchboard,
-    teller,
-    credit_engine,
-    simple_erc20_vault,
-    bob,
-    alice,
-    alpha_token,
-    alpha_token_whale,
-    setupDeleverage,
-    setup_priority_configs,
-    mission_control,
-    deleverage,
-    mock_undy_v2,
-    switchboard_alpha,
-):
-    """Underscore non-earn callers stay trusted and still get full-payoff extras."""
-    mission_control.setUnderscoreRegistry(mock_undy_v2.address, sender=switchboard_alpha.address)
-    mock_undy_v2.setAllAddressesAreVaults(False)
-    mock_undy_v2.setEarnVault(alice, False)
-    mock_undy_v2.setBasicEarnVault(alice, False)
-
-    deleverage.setDeleverageFullPayoffParam(1, 10**15, sender=switchboard_alpha.address)
-    deleverage.setDeleverageFullPayoffParam(2, 100, sender=switchboard_alpha.address)
-    deleverage.setDeleverageFullPayoffParam(3, 0, sender=switchboard_alpha.address)
-    deleverage.setDeleverageFullPayoffParam(4, 0, sender=switchboard_alpha.address)
 
     setupDeleverage(
         bob,
@@ -3467,5 +3570,62 @@ def test_full_payoff_extras_apply_for_underscore_non_earn_caller(
         pre_debt + expected_overage,
         pre_debt,
     )
+
+    mock_undy_v2.setAllAddressesAreVaults(True)
+
+
+def test_full_payoff_extras_disabled_for_earn_vault_user_when_caller_is_non_earn(
+    ripe_hq,
+    switchboard,
+    teller,
+    credit_engine,
+    simple_erc20_vault,
+    bob,
+    alice,
+    alpha_token,
+    alpha_token_whale,
+    setupDeleverage,
+    setup_priority_configs,
+    mission_control,
+    deleverage,
+    mock_undy_v2,
+    switchboard_alpha,
+):
+    """An earn-vault position owner suppresses extras regardless of caller type."""
+    mission_control.setUnderscoreRegistry(mock_undy_v2.address, sender=switchboard_alpha.address)
+    mock_undy_v2.setAllAddressesAreVaults(False)
+    mock_undy_v2.setEarnVault(alice, False)
+    mock_undy_v2.setBasicEarnVault(alice, False)
+    mock_undy_v2.setEarnVault(bob, True)
+    mock_undy_v2.setBasicEarnVault(bob, False)
+
+    deleverage.setDeleverageFullPayoffParam(1, 10**15, sender=switchboard_alpha.address)
+    deleverage.setDeleverageFullPayoffParam(2, 100, sender=switchboard_alpha.address)
+    deleverage.setDeleverageFullPayoffParam(3, 0, sender=switchboard_alpha.address)
+    deleverage.setDeleverageFullPayoffParam(4, 0, sender=switchboard_alpha.address)
+
+    setupDeleverage(
+        bob,
+        alpha_token,
+        alpha_token_whale,
+        deposit_amount=1_000 * EIGHTEEN_DECIMALS,
+        borrow_amount=500 * EIGHTEEN_DECIMALS,
+        get_sgreen=False,
+    )
+    setup_priority_configs(
+        priority_stab_assets=[],
+        priority_liq_assets=[(simple_erc20_vault, alpha_token)],
+    )
+
+    pre_debt = credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount
+    repaid_amount = teller.deleverageUser(bob, 0, sender=alice)
+
+    assert repaid_amount == pre_debt
+    assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == 0
+
+    transfer_log = filter_logs(teller, "EndaomentTransferDuringDeleverage")[-1]
+    deleverage_log = filter_logs(teller, "DeleverageUser")[-1]
+    assert transfer_log.usdValue == pre_debt
+    _assert_deleverage_user_amounts(deleverage_log, pre_debt, pre_debt, pre_debt, pre_debt)
 
     mock_undy_v2.setAllAddressesAreVaults(True)

--- a/tests/core/deleverage/test_deleverage_specific_assets.py
+++ b/tests/core/deleverage/test_deleverage_specific_assets.py
@@ -483,7 +483,7 @@ def test_full_payoff_specific_assets_forgives_dust_after_real_collateral(
     assert main_log.debtToClear == pre_debt
 
 
-def test_full_payoff_specific_assets_excludes_underscore_earn_vault_caller(
+def test_full_payoff_specific_assets_uses_owner_not_earn_vault_caller(
     switchboard_alpha,
     deleverage,
     teller,
@@ -498,8 +498,7 @@ def test_full_payoff_specific_assets_excludes_underscore_earn_vault_caller(
     mock_undy_v2,
 ):
     """
-    Underscore earn-vault callers remain trusted, but they do not get the new
-    full-payoff buffer or dust behavior.
+    Caller classification must not suppress extras for an ordinary user.
     """
     mission_control.setUnderscoreRegistry(mock_undy_v2.address, sender=switchboard_alpha.address)
     mock_undy_v2.setAllAddressesAreVaults(False)
@@ -525,6 +524,7 @@ def test_full_payoff_specific_assets_excludes_underscore_earn_vault_caller(
     )
 
     pre_debt = credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount
+    expected_overage = min(10**15, pre_debt * 100 // 100_00)
     pre_bravo_vault = simple_erc20_vault.getTotalAmountForUser(bob, bravo_token)
 
     assets = [(3, bravo_token.address, pre_debt)]
@@ -538,11 +538,11 @@ def test_full_payoff_specific_assets_excludes_underscore_earn_vault_caller(
 
     assert repaid_amount == pre_debt
     assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == 0
-    assert pre_bravo_vault - post_bravo_vault == pre_debt
-    assert transfer_log.usdValue == pre_debt
+    assert pre_bravo_vault - post_bravo_vault == pre_debt + expected_overage
+    assert transfer_log.usdValue == pre_debt + expected_overage
     assert main_log.targetRepayAmount == pre_debt
-    assert main_log.targetRepayAmountWithBuffer == pre_debt
-    assert main_log.collateralValueRepaid == pre_debt
+    assert main_log.targetRepayAmountWithBuffer == pre_debt + expected_overage
+    assert main_log.collateralValueRepaid == pre_debt + expected_overage
     assert main_log.debtToClear == pre_debt
 
 


### PR DESCRIPTION
## Summary

Addresses the review feedback on [PR #61](https://github.com/Ripe-Foundation/ripe-protocol/pull/61) as a stacked change:

- key full-payoff protection to the position owner and classify batch users independently
- restore lazy Underscore caller resolution and key the transient vault-registry cache
- preflight dust-sized basic earn-vault withdrawals in AuctionHouse before collateral moves
- retain the post-withdraw conversion invariant and add defense-in-depth ceilings for the four new payoff parameters
- add withdrawal, batch-isolation, owner/caller, registry-health, setter-ceiling, and deployed-size coverage
- add staged AuctionHouse/Deleverage and SwitchboardDelta migrations, with all four new value-transferring parameters initialized to zero
- regenerate the affected ABIs and allow local test collection without an Etherscan API key

## Why

The original implementation could classify full-payoff extras from the caller rather than the position owner, make healthy Ripe paths depend unnecessarily on the Underscore registry, and let a dust earn-vault share revert batch deleveraging after withdrawal. The reviewed fix must also operate within Deleverage's EIP-170 bytecode ceiling.

The approved design keeps the pre-withdrawal safe-conversion check in the Deleverage-gated AuctionHouse wrapper. A Deleverage-only prototype remained 92 bytes over EIP-170 even after removing the four new in-contract caps.

## Deployment and residual constraints

- Deleverage deploys at 24,553 bytes, leaving 23 bytes of EIP-170 headroom.
- AuctionHouse deploys at 24,389 bytes.
- The migrations preserve the four live legacy values and initialize the four new payoff parameters to zero.
- A pinned Base-mainnet fork run through `scripts/migrate.py` and retention of the MigrationRunner log remain required before scheduling the migrations.
- Governance must decide surplus/exit-fee versus post-rounding shortfall-top-up semantics before enabling non-zero payoff values.
- A configured broken Underscore registry can still block owner-keyed full-payoff classification and CreditEngine owner reads; setting the registry to zero is the documented escape hatch.
- A vault that sends fewer shares than the preflighted balance can still hit the retained post-withdraw conversion invariant.
- The changed `DeleverageUser` event signature requires off-chain indexer/keeper coordination.

## Validation

- 413 Deleverage/SwitchboardDelta tests passed with `ETHERSCAN_API_KEY` unset
- 91 AuctionHouse tests passed
- generated ABIs exactly match the checked-in AuctionHouse, Deleverage, and SwitchboardDelta ABIs (36/47/191 entries)
- exact deployed-size assertions pass
- `git diff --check` is clean

## Stack

- **Base:** `deleverage-updates` / PR #61
- **Head:** `codex/pr61-review-fixes`
- This PR is intentionally targeted at the PR #61 branch, not `master`.

## Merge strategy and sequencing

- Preserve the independently validated `c9b2142` head; do not amend or force-push it solely to add commit prose.
- Squash-merge this PR into `deleverage-updates`.
- This repository defaults the squash body to the source commit messages. Because the single source commit is subject-only, replace the generated squash body with this PR description (or a faithful condensed version) so the rationale, validation, and residual constraints land in git history.
- After this PR lands, rebase the combined `deleverage-updates` branch onto current `master` once. Do not separately rebase both layers of the stack.
