### PR TITLE
fix: harden PR #61 review follow-up

### DIFF
--- a/contracts/core/AuctionHouse.vy
+++ b/contracts/core/AuctionHouse.vy
@@ -18,6 +18,9 @@
 
 # @version 0.4.3
 # pragma optimize codesize
+# At this source revision, the deployed runtime is 24,469 bytes including
+# Vyper's 96-byte immutables section: 107 bytes of EIP-170 headroom.
+# Re-measure the actual deployed code before making any runtime-affecting change.
 
 implements: Department
 
@@ -1195,10 +1198,11 @@ def withdrawTokensFromVault(
 ) -> (uint256, bool):
     assert msg.sender == addys._getDeleverageAddr() # dev: only deleverage allowed
     if _preflightSafeConversion:
-        # Use the balance the vault can debit, not the larger requested amount.
-        # If the vault still sends less and that smaller amount converts to zero,
-        # Deleverage's retained post-withdraw invariant assertion will revert.
+        # Mirror BasicVault's user-ledger and token-balance clamps before it
+        # mutates either state. Deleverage retains a post-withdraw consistency
+        # assertion for any vault or asset behavior outside these known bounds.
         withdrawableAmount: uint256 = min(_amount, staticcall Vault(_vaultAddr).getTotalAmountForUser(_user, _asset))
+        withdrawableAmount = min(withdrawableAmount, staticcall IERC20(_asset).balanceOf(_vaultAddr))
         if staticcall UnderscoreVault(_asset).convertToAssetsSafe(withdrawableAmount) == 0:
             return 0, False
     return extcall Vault(_vaultAddr).withdrawTokensFromVault(_user, _asset, _amount, _recipient, _a)

--- a/contracts/core/Deleverage.vy
+++ b/contracts/core/Deleverage.vy
@@ -368,7 +368,7 @@ def deleverageWithSpecificAssets(_user: address, _assets: DynArray[DeleverageAss
                 # Owner-keyed full-payoff classification necessarily depends on
                 # the configured Underscore registry being healthy even when all
                 # payoff extras are zero. Governance can set that registry to
-                # zero to restore Ripe-only operation.
+                # zero to restore Ripe-only operation only while extras stay off.
                 useFullPayoffExtras = self._getUnderscoreAddrType(_user, a.missionControl, False) != UNDERSCORE_EARN_VAULT_CALLER_TYPE
             if useFullPayoffExtras:
                 # Full-payoff intent lets the buffer exceed this asset's target.
@@ -721,7 +721,7 @@ def _deleverageUser(
         # Owner-keyed full-payoff classification necessarily depends on the
         # configured Underscore registry being healthy even when all payoff
         # extras are zero. Governance can set that registry to zero to restore
-        # Ripe-only operation.
+        # Ripe-only operation only while extras stay off.
         useFullPayoffExtras = self._getUnderscoreAddrType(_user, _a.missionControl, False) != UNDERSCORE_EARN_VAULT_CALLER_TYPE
 
     # get extra collateral if buffer params set (either usd value or bps over debt amount)
@@ -1204,6 +1204,8 @@ def _transferCollateral(
         na: uint256 = 0
         cappedUnderlying: uint256 = 0
         na, cappedUnderlying = self._getMaxAndCappedUnderlyingForShares(_asset, amountSent)
+        # AuctionHouse preflights BasicVault's known amount clamps; retain this
+        # as a consistency invariant for divergent vault or asset behavior.
         assert cappedUnderlying != 0 # dev: zero safe underlying
         usdValue = staticcall PriceDesk(_a.priceDesk).getUsdValue(underlyingAsset, cappedUnderlying, True)
 
@@ -1221,6 +1223,8 @@ def _getUnderscoreAddrType(_addr: address, _mc: address, _basicEarnVaultOnly: bo
     # Writes the underscore vault registry to transient cache, so do not use from @view paths.
     underscore: address = staticcall MissionControl(_mc).underscoreRegistry()
     if underscore == empty(address):
+        # The zero-registry escape hatch cannot identify earn-vault owners, so
+        # governance must keep full-payoff extras disabled while using it.
         return 0
 
     vaultRegistry: address = self._getUnderscoreVaultRegistry(underscore)

--- a/contracts/mock/MockErc4626VaultWithSafeGap.vy
+++ b/contracts/mock/MockErc4626VaultWithSafeGap.vy
@@ -19,6 +19,7 @@ balanceOf: public(HashMap[address, uint256])
 totalSupply: public(uint256)
 allowance: public(HashMap[address, HashMap[address, uint256]])
 safeDiscountBps: public(uint256)
+zeroSafeConversionOnTransfer: public(bool)
 
 HUNDRED_PERCENT: constant(uint256) = 100_00
 
@@ -34,6 +35,11 @@ def __init__(_asset: address, _safeDiscountBps: uint256):
 def setSafeDiscountBps(_safeDiscountBps: uint256):
     assert _safeDiscountBps <= HUNDRED_PERCENT  # dev: invalid safe discount
     self.safeDiscountBps = _safeDiscountBps
+
+
+@external
+def setZeroSafeConversionOnTransfer(_shouldZero: bool):
+    self.zeroSafeConversionOnTransfer = _shouldZero
 
 
 @external
@@ -123,6 +129,8 @@ def _amountToShares(_amount: uint256) -> uint256:
 
 @external
 def transfer(_to: address, _value: uint256) -> bool:
+    if self.zeroSafeConversionOnTransfer:
+        self.safeDiscountBps = HUNDRED_PERCENT
     self.balanceOf[msg.sender] -= _value
     self.balanceOf[_to] += _value
     log Transfer(sender=msg.sender, receiver=_to, value=_value)

--- a/tests/conf_utils.py
+++ b/tests/conf_utils.py
@@ -6,6 +6,20 @@ def filter_logs(contract, event_name, _strict=False):
     return [e for e in contract.get_logs(strict=_strict) if type(e).__name__ == event_name]
 
 
+def set_full_payoff_params(
+    deleverage,
+    switchboard_alpha,
+    buffer_amount=0,
+    overage_bps=0,
+    dust_threshold=0,
+    dust_bps=0,
+):
+    deleverage.setDeleverageFullPayoffParam(1, buffer_amount, sender=switchboard_alpha.address)
+    deleverage.setDeleverageFullPayoffParam(2, overage_bps, sender=switchboard_alpha.address)
+    deleverage.setDeleverageFullPayoffParam(3, dust_threshold, sender=switchboard_alpha.address)
+    deleverage.setDeleverageFullPayoffParam(4, dust_bps, sender=switchboard_alpha.address)
+
+
 @pytest.fixture(scope="session")
 def _test():
     def _test(_expectedValue, _actualValue, _buffer=50):

--- a/tests/core/deleverage/test_deleverage_permissions.py
+++ b/tests/core/deleverage/test_deleverage_permissions.py
@@ -1,7 +1,7 @@
 import pytest
 import boa
 from constants import EIGHTEEN_DECIMALS, ZERO_ADDRESS
-from conf_utils import filter_logs
+from conf_utils import filter_logs, set_full_payoff_params
 
 HUNDRED_PERCENT = 100_00
 SIX_DECIMALS = 10**6
@@ -1764,6 +1764,7 @@ def test_local_trust_checks_do_not_depend_on_underscore_registry_health(
 
 def test_full_payoff_owner_classification_depends_on_registry_health(
     switchboard_alpha,
+    deleverage,
     teller,
     credit_engine,
     simple_erc20_vault,
@@ -1802,6 +1803,17 @@ def test_full_payoff_owner_classification_depends_on_registry_health(
         sender=switchboard_alpha.address,
     )
     mock_undy_v2.setAllAddressesAreVaults(False)
+    mock_undy_v2.setEarnVault(bob, True)
+    mock_undy_v2.setBasicEarnVault(bob, False)
+    full_payoff_buffer = 10**15
+    set_full_payoff_params(
+        deleverage,
+        switchboard_alpha,
+        buffer_amount=full_payoff_buffer,
+        overage_bps=100,
+        dust_threshold=10**15,
+        dust_bps=100,
+    )
     mock_undy_v2.setVaultCheckRevertAddress(bob)
 
     # The caller is locally trusted, but a full payoff still classifies the
@@ -1819,13 +1831,16 @@ def test_full_payoff_owner_classification_depends_on_registry_health(
     assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == pre_debt
     assert simple_erc20_vault.getTotalAmountForUser(bob, alpha_token) == pre_collateral
 
-    # Governance's documented escape hatch removes the external dependency.
+    # Governance's documented escape hatch removes the external dependency,
+    # but also makes earn-vault owners indistinguishable from ordinary owners.
     mock_undy_v2.setVaultCheckRevertAddress(bob)
     mission_control.setUnderscoreRegistry(
         ZERO_ADDRESS,
         sender=switchboard_alpha.address,
     )
     assert teller.deleverageUser(bob, 0, sender=switchboard_alpha.address) > 0
+    deleverage_log = filter_logs(teller, "DeleverageUser")[0]
+    assert deleverage_log.targetRepayAmountWithBuffer == pre_debt + full_payoff_buffer
     assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == 0
 
 

--- a/tests/core/deleverage/test_deleverage_phase2.py
+++ b/tests/core/deleverage/test_deleverage_phase2.py
@@ -1,7 +1,7 @@
 import pytest
 import boa
 from constants import EIGHTEEN_DECIMALS, ZERO_ADDRESS
-from conf_utils import filter_logs
+from conf_utils import filter_logs, set_full_payoff_params
 
 SIX_DECIMALS = 10**6  # For tokens like USDC/Charlie that have 6 decimals
 
@@ -89,6 +89,7 @@ def setup(
     mock_undy_v2.setAllAddressesAreVaults(True)
     mock_undy_v2.setVaultCheckRevertAddress(ZERO_ADDRESS)
     alpha_token_vault_with_safe_gap.setSafeDiscountBps(500)
+    alpha_token_vault_with_safe_gap.setZeroSafeConversionOnTransfer(False)
 
 
 def test_basic_endaoment_transfer(
@@ -2408,6 +2409,221 @@ def test_phase2_underscore_earn_vault_dust_amount_safe_zero_skips_before_withdra
     assert alpha_token_vault_with_safe_gap.balanceOf(endaoment_funds) == pre_endaoment_shares
 
 
+def test_phase2_underscore_earn_vault_balance_clamp_safe_zero_skips_before_withdrawal(
+    ripe_hq,  # Ensures switchboard is registered
+    switchboard,  # Ensures switchboard_alpha is registered
+    teller,
+    credit_engine,
+    simple_erc20_vault,
+    bob,
+    alpha_token,
+    alpha_token_whale,
+    alpha_token_vault_with_safe_gap,
+    performDeposit,
+    setupDeleverage,
+    setup_priority_configs,
+    setAssetConfig,
+    createDebtTerms,
+    mock_price_source,
+    mission_control,
+    mock_undy_v2,
+    endaoment_funds,
+    switchboard_alpha,
+):
+    """Preflight the vault's actual token balance before its withdrawal clamp."""
+    mission_control.setUnderscoreRegistry(mock_undy_v2.address, sender=switchboard_alpha.address)
+    mock_undy_v2.setAllAddressesAreVaults(False)
+    mock_undy_v2.setEarnVault(alpha_token_vault_with_safe_gap.address, True)
+    mock_undy_v2.setBasicEarnVault(alpha_token_vault_with_safe_gap.address, True)
+    alpha_token_vault_with_safe_gap.setSafeDiscountBps(9999)
+
+    mock_price_source.setPrice(alpha_token, EIGHTEEN_DECIMALS)
+    debt_terms = createDebtTerms(
+        _ltv=80_00,
+        _redemptionThreshold=85_00,
+        _liqThreshold=90_00,
+        _liqFee=5_00,
+        _borrowRate=0,
+    )
+    setAssetConfig(
+        alpha_token_vault_with_safe_gap,
+        _vaultIds=[3],
+        _debtTerms=debt_terms,
+        _shouldBurnAsPayment=False,
+        _shouldTransferToEndaoment=True,
+    )
+    setAssetConfig(
+        alpha_token,
+        _vaultIds=[3],
+        _debtTerms=debt_terms,
+        _shouldBurnAsPayment=False,
+        _shouldTransferToEndaoment=True,
+    )
+
+    setupDeleverage(
+        bob,
+        alpha_token,
+        alpha_token_whale,
+        deposit_amount=1_000 * EIGHTEEN_DECIMALS,
+        borrow_amount=20 * EIGHTEEN_DECIMALS,
+        get_sgreen=False,
+    )
+
+    alpha_token.transfer(bob, 100 * EIGHTEEN_DECIMALS, sender=alpha_token_whale)
+    alpha_token.approve(alpha_token_vault_with_safe_gap, 100 * EIGHTEEN_DECIMALS, sender=bob)
+    alpha_token_vault_with_safe_gap.deposit(100 * EIGHTEEN_DECIMALS, bob, sender=bob)
+    alpha_token.transfer(alpha_token_vault_with_safe_gap, 100 * EIGHTEEN_DECIMALS, sender=alpha_token_whale)
+    performDeposit(
+        bob,
+        100 * EIGHTEEN_DECIMALS,
+        alpha_token_vault_with_safe_gap,
+        bob,
+        simple_erc20_vault,
+    )
+
+    pre_vault_shares = simple_erc20_vault.getTotalAmountForUser(
+        bob,
+        alpha_token_vault_with_safe_gap,
+    )
+    alpha_token_vault_with_safe_gap.transfer(
+        alpha_token_whale,
+        pre_vault_shares - 1,
+        sender=simple_erc20_vault.address,
+    )
+    assert alpha_token_vault_with_safe_gap.balanceOf(simple_erc20_vault) == 1
+    assert alpha_token_vault_with_safe_gap.convertToAssetsSafe(pre_vault_shares) != 0
+    assert alpha_token_vault_with_safe_gap.convertToAssetsSafe(1) == 0
+
+    setup_priority_configs(
+        priority_stab_assets=[],
+        priority_liq_assets=[
+            (simple_erc20_vault, alpha_token_vault_with_safe_gap),
+            (simple_erc20_vault, alpha_token),
+        ],
+    )
+
+    target_repay = 10 * EIGHTEEN_DECIMALS
+    pre_debt = credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount
+    pre_endaoment_shares = alpha_token_vault_with_safe_gap.balanceOf(endaoment_funds)
+    repaid = teller.deleverageUser(
+        bob,
+        target_repay,
+        sender=switchboard_alpha.address,
+    )
+
+    assert repaid == target_repay
+    assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == pre_debt - target_repay
+    assert simple_erc20_vault.getTotalAmountForUser(
+        bob,
+        alpha_token_vault_with_safe_gap,
+    ) == pre_vault_shares
+    assert alpha_token_vault_with_safe_gap.balanceOf(simple_erc20_vault) == 1
+    assert alpha_token_vault_with_safe_gap.balanceOf(endaoment_funds) == pre_endaoment_shares
+
+
+def test_phase2_underscore_earn_vault_post_withdraw_safe_zero_reverts_atomically(
+    ripe_hq,  # Ensures switchboard is registered
+    switchboard,  # Ensures switchboard_alpha is registered
+    teller,
+    credit_engine,
+    simple_erc20_vault,
+    bob,
+    alpha_token,
+    alpha_token_whale,
+    alpha_token_vault_with_safe_gap,
+    performDeposit,
+    setupDeleverage,
+    setup_priority_configs,
+    setAssetConfig,
+    createDebtTerms,
+    mock_price_source,
+    mission_control,
+    mock_undy_v2,
+    endaoment_funds,
+    switchboard_alpha,
+):
+    """The retained post-withdraw safe-conversion invariant reverts atomically."""
+    mission_control.setUnderscoreRegistry(mock_undy_v2.address, sender=switchboard_alpha.address)
+    mock_undy_v2.setAllAddressesAreVaults(False)
+    mock_undy_v2.setEarnVault(alpha_token_vault_with_safe_gap.address, True)
+    mock_undy_v2.setBasicEarnVault(alpha_token_vault_with_safe_gap.address, True)
+    alpha_token_vault_with_safe_gap.setSafeDiscountBps(500)
+
+    mock_price_source.setPrice(alpha_token, EIGHTEEN_DECIMALS)
+    debt_terms = createDebtTerms(
+        _ltv=80_00,
+        _redemptionThreshold=85_00,
+        _liqThreshold=90_00,
+        _liqFee=5_00,
+        _borrowRate=0,
+    )
+    setAssetConfig(
+        alpha_token_vault_with_safe_gap,
+        _vaultIds=[3],
+        _debtTerms=debt_terms,
+        _shouldBurnAsPayment=False,
+        _shouldTransferToEndaoment=True,
+    )
+    setAssetConfig(
+        alpha_token,
+        _vaultIds=[3],
+        _debtTerms=debt_terms,
+        _shouldBurnAsPayment=False,
+        _shouldTransferToEndaoment=False,
+    )
+
+    setupDeleverage(
+        bob,
+        alpha_token,
+        alpha_token_whale,
+        deposit_amount=1_000 * EIGHTEEN_DECIMALS,
+        borrow_amount=20 * EIGHTEEN_DECIMALS,
+        get_sgreen=False,
+    )
+
+    alpha_token.transfer(bob, 100 * EIGHTEEN_DECIMALS, sender=alpha_token_whale)
+    alpha_token.approve(alpha_token_vault_with_safe_gap, 100 * EIGHTEEN_DECIMALS, sender=bob)
+    alpha_token_vault_with_safe_gap.deposit(100 * EIGHTEEN_DECIMALS, bob, sender=bob)
+    performDeposit(
+        bob,
+        100 * EIGHTEEN_DECIMALS,
+        alpha_token_vault_with_safe_gap,
+        bob,
+        simple_erc20_vault,
+    )
+    alpha_token.transfer(alpha_token_vault_with_safe_gap, 100 * EIGHTEEN_DECIMALS, sender=alpha_token_whale)
+    assert alpha_token_vault_with_safe_gap.convertToAssetsSafe(EIGHTEEN_DECIMALS) != 0
+
+    setup_priority_configs(
+        priority_stab_assets=[],
+        priority_liq_assets=[(simple_erc20_vault, alpha_token_vault_with_safe_gap)],
+    )
+
+    target_repay = 10 * EIGHTEEN_DECIMALS
+    pre_debt = credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount
+    pre_vault_shares = simple_erc20_vault.getTotalAmountForUser(
+        bob,
+        alpha_token_vault_with_safe_gap,
+    )
+    pre_endaoment_shares = alpha_token_vault_with_safe_gap.balanceOf(endaoment_funds)
+    alpha_token_vault_with_safe_gap.setZeroSafeConversionOnTransfer(True)
+
+    with boa.reverts("zero safe underlying"):
+        teller.deleverageUser(
+            bob,
+            target_repay,
+            sender=switchboard_alpha.address,
+        )
+
+    assert credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount == pre_debt
+    assert simple_erc20_vault.getTotalAmountForUser(
+        bob,
+        alpha_token_vault_with_safe_gap,
+    ) == pre_vault_shares
+    assert alpha_token_vault_with_safe_gap.balanceOf(endaoment_funds) == pre_endaoment_shares
+    assert alpha_token_vault_with_safe_gap.safeDiscountBps() == 500
+
+
 def test_phase2_dust_user_does_not_revert_later_healthy_batch_user(
     ripe_hq,
     switchboard,
@@ -2601,24 +2817,6 @@ def test_phase2_underscore_earn_vault_depleted_position_credits_from_amount_sent
     mock_undy_v2.setAllAddressesAreVaults(True)
 
 
-#################################################
-# Full-Payoff Dust Cleanup Settings
-#################################################
-
-def _set_full_payoff_params(
-    deleverage,
-    switchboard_alpha,
-    buffer_amount=0,
-    overage_bps=0,
-    dust_threshold=0,
-    dust_bps=0,
-):
-    deleverage.setDeleverageFullPayoffParam(1, buffer_amount, sender=switchboard_alpha.address)
-    deleverage.setDeleverageFullPayoffParam(2, overage_bps, sender=switchboard_alpha.address)
-    deleverage.setDeleverageFullPayoffParam(3, dust_threshold, sender=switchboard_alpha.address)
-    deleverage.setDeleverageFullPayoffParam(4, dust_bps, sender=switchboard_alpha.address)
-
-
 def _configure_alpha_borrow_bravo_deleverage(
     setAssetConfig,
     createDebtTerms,
@@ -2661,13 +2859,20 @@ def _assert_deleverage_user_amounts(
 
 def test_actual_deployed_runtime_stays_under_eip170(deleverage, auction_house):
     """Measure on-chain code, including the 96 bytes absent from compiler_data."""
+    EIP170_LIMIT = 24_576
     deleverage_size = len(boa.env.get_code(deleverage.address))
     auction_house_size = len(boa.env.get_code(auction_house.address))
 
-    assert deleverage_size == 24_553
-    assert auction_house_size == 24_389
-    assert deleverage_size <= 24_576
-    assert auction_house_size <= 24_576
+    # Measured at this revision: Deleverage 24,553 bytes (23 bytes headroom),
+    # AuctionHouse 24,469 bytes (107 bytes headroom).
+    assert deleverage_size <= EIP170_LIMIT, (
+        f"Deleverage runtime is {deleverage_size} bytes; "
+        f"EIP-170 limit is {EIP170_LIMIT} bytes"
+    )
+    assert auction_house_size <= EIP170_LIMIT, (
+        f"AuctionHouse runtime is {auction_house_size} bytes; "
+        f"EIP-170 limit is {EIP170_LIMIT} bytes"
+    )
 
 
 @pytest.mark.parametrize(
@@ -2768,7 +2973,7 @@ def test_full_payoff_buffer_consumes_extra_collateral_and_exposes_overage(
     switchboard_alpha,
 ):
     """Full-payoff buffer lifts collateral target, caps debt repayment, and exposes overage in events."""
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         buffer_amount=10**15,
@@ -2824,7 +3029,7 @@ def test_full_payoff_max_buffer_params_stay_bounded(
     switchboard_alpha,
 ):
     """Max Switchboard buffer params exercise cap-bounded unsafe math without changing debt accounting."""
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         buffer_amount=10**18,
@@ -2882,7 +3087,7 @@ def test_full_payoff_buffer_requires_both_absolute_and_bps_config(
     overage_bps,
 ):
     """The buffer path is disabled until both the absolute buffer and overage bps are nonzero."""
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         buffer_amount=buffer_amount,
@@ -2942,7 +3147,7 @@ def test_full_payoff_dust_forgiveness_clears_sub_threshold_remainder(
         bravo_token,
     )
 
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         dust_threshold=1,
@@ -3011,7 +3216,7 @@ def test_full_payoff_max_dust_params_clear_threshold_boundary(
         alpha_token,
         bravo_token,
     )
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         dust_threshold=10**16,
@@ -3077,7 +3282,7 @@ def test_full_payoff_dust_forgiveness_respects_bps_cap_for_small_debt(
         bravo_token,
     )
 
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         dust_threshold=10**15,
@@ -3142,7 +3347,7 @@ def test_full_payoff_dust_forgiveness_requires_absolute_and_bps_config(
         alpha_token,
         bravo_token,
     )
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         dust_threshold=dust_threshold,
@@ -3204,7 +3409,7 @@ def test_full_payoff_dust_forgiveness_respects_absolute_threshold(
         alpha_token,
         bravo_token,
     )
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         dust_threshold=1,
@@ -3266,7 +3471,7 @@ def test_full_payoff_dust_forgiveness_blocks_when_both_caps_fail(
         alpha_token,
         bravo_token,
     )
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         dust_threshold=1,
@@ -3317,7 +3522,7 @@ def test_full_payoff_extras_do_not_apply_to_partial_targets(
     switchboard_alpha,
 ):
     """Partial deleverage targets use the requested debt target without buffer or forgiveness."""
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         buffer_amount=10**15,
@@ -3370,7 +3575,7 @@ def test_full_payoff_extras_do_not_turn_zero_repayment_into_forgiveness(
     switchboard_alpha,
 ):
     """Even with permissive params, a full-payoff call with no eligible collateral still reverts."""
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         buffer_amount=10**15,
@@ -3434,7 +3639,7 @@ def test_full_payoff_buffer_applies_to_admin_with_basic_underscore_collateral(
     mock_undy_v2.setBasicEarnVault(alpha_token_vault_with_safe_gap.address, True)
     alpha_token_vault_with_safe_gap.setSafeDiscountBps(500)
 
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         buffer_amount=10**15,

--- a/tests/core/deleverage/test_deleverage_specific_assets.py
+++ b/tests/core/deleverage/test_deleverage_specific_assets.py
@@ -1,23 +1,9 @@
 import pytest
 import boa
 from constants import EIGHTEEN_DECIMALS
-from conf_utils import filter_logs
+from conf_utils import filter_logs, set_full_payoff_params
 
 SIX_DECIMALS = 10**6  # For tokens like USDC/Charlie that have 6 decimals
-
-
-def _set_full_payoff_params(
-    deleverage,
-    switchboard_alpha,
-    buffer_amount=0,
-    overage_bps=0,
-    dust_threshold=0,
-    dust_bps=0,
-):
-    deleverage.setDeleverageFullPayoffParam(1, buffer_amount, sender=switchboard_alpha.address)
-    deleverage.setDeleverageFullPayoffParam(2, overage_bps, sender=switchboard_alpha.address)
-    deleverage.setDeleverageFullPayoffParam(3, dust_threshold, sender=switchboard_alpha.address)
-    deleverage.setDeleverageFullPayoffParam(4, dust_bps, sender=switchboard_alpha.address)
 
 
 @pytest.fixture(autouse=True)
@@ -288,7 +274,7 @@ def test_partial_target_specific_assets_do_not_use_full_payoff_extras(
     """
     Enabled full-payoff params must not add buffer or forgive dust for partial targets.
     """
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         buffer_amount=10**15,
@@ -343,7 +329,7 @@ def test_full_payoff_single_specific_asset_uses_buffer(
     """
     full_payoff_buffer = 10**15
     full_payoff_overage_bps = 100
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         buffer_amount=full_payoff_buffer,
@@ -404,7 +390,7 @@ def test_full_payoff_specific_assets_max_buffer_params_stay_bounded(
     """
     Specific-asset full payoff remains bounded when buffer params are at Switchboard caps.
     """
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         buffer_amount=10**18,
@@ -459,7 +445,7 @@ def test_full_payoff_specific_assets_forgives_dust_after_real_collateral(
     Dust forgiveness applies to specific-assets full payoff only after nonzero
     collateral was consumed and both dust caps allow the remainder.
     """
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         dust_threshold=1,
@@ -516,7 +502,7 @@ def test_full_payoff_specific_assets_uses_owner_not_earn_vault_caller(
     mock_undy_v2.setEarnVault(alice, True)
     mock_undy_v2.setBasicEarnVault(alice, False)
 
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         buffer_amount=10**15,
@@ -557,6 +543,64 @@ def test_full_payoff_specific_assets_uses_owner_not_earn_vault_caller(
     assert main_log.debtToClear == pre_debt
 
 
+def test_full_payoff_specific_assets_disabled_for_earn_vault_user_when_caller_is_non_earn(
+    switchboard_alpha,
+    deleverage,
+    teller,
+    credit_engine,
+    simple_erc20_vault,
+    bob,
+    bravo_token,
+    bravo_token_whale,
+    setupDeleverage,
+    mission_control,
+    mock_undy_v2,
+):
+    """An earn-vault position owner must not lose extra collateral, whoever calls."""
+    mission_control.setUnderscoreRegistry(mock_undy_v2.address, sender=switchboard_alpha.address)
+    mock_undy_v2.setAllAddressesAreVaults(False)
+    mock_undy_v2.setEarnVault(bob, True)
+    mock_undy_v2.setBasicEarnVault(bob, False)
+
+    set_full_payoff_params(
+        deleverage,
+        switchboard_alpha,
+        buffer_amount=10**15,
+        overage_bps=100,
+        dust_threshold=10**15,
+        dust_bps=100,
+    )
+    setupDeleverage(
+        bob,
+        bravo_token,
+        bravo_token_whale,
+        deposit_amount=500 * EIGHTEEN_DECIMALS,
+        borrow_amount=300 * EIGHTEEN_DECIMALS,
+        get_sgreen=False,
+    )
+
+    pre_debt = credit_engine.getLatestUserDebtAndTerms(bob, False)[0].amount
+    pre_bravo_vault = simple_erc20_vault.getTotalAmountForUser(bob, bravo_token)
+
+    assets = [(3, bravo_token.address, pre_debt)]
+    repaid_amount = teller.deleverageWithSpecificAssets(
+        assets,
+        bob,
+        sender=switchboard_alpha.address,
+    )
+
+    transfer_log = filter_logs(teller, "EndaomentTransferDuringDeleverage")[0]
+    main_log = filter_logs(teller, "DeleverageUser")[0]
+    post_bravo_vault = simple_erc20_vault.getTotalAmountForUser(bob, bravo_token)
+
+    assert repaid_amount == pre_debt
+    assert pre_bravo_vault - post_bravo_vault == pre_debt
+    assert transfer_log.usdValue == pre_debt
+    assert main_log.targetRepayAmountWithBuffer == pre_debt
+    assert main_log.collateralValueRepaid == pre_debt
+    assert main_log.debtToClear == pre_debt
+
+
 def test_full_payoff_specific_assets_carries_buffer_after_depleted_trigger_asset(
     switchboard_alpha,
     deleverage,
@@ -583,7 +627,7 @@ def test_full_payoff_specific_assets_carries_buffer_after_depleted_trigger_asset
     """
     full_payoff_buffer = 10**15
     full_payoff_overage_bps = 100
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         buffer_amount=full_payoff_buffer,
@@ -1230,7 +1274,7 @@ def test_full_payoff_specific_assets_all_skipped_still_reverts(
     """
     Full-payoff buffer cannot turn skipped/non-deleveragable assets into a debt clear.
     """
-    _set_full_payoff_params(
+    set_full_payoff_params(
         deleverage,
         switchboard_alpha,
         buffer_amount=10**15,


### PR DESCRIPTION
## Summary

Follow-up hardening for the latest review of #61:

- preflight basic earn-vault withdrawals against both user accounting and the vault's actual token balance
- add the missing specific-assets owner-classification regression
- document and test the zero-registry/full-payoff-extras coupling with payoff parameters enabled
- add direct coverage for the retained post-withdraw safe-conversion invariant
- replace exact runtime-size equality checks with EIP-170 ceiling checks and record measured headroom
- centralize the full-payoff parameter test helper and preserve fixture intent comments

## Why

The second-pass review found that the prior registry-zero assertion was vacuous, the retained safe-conversion invariant had no discriminating test, and AuctionHouse's 80-byte runtime growth had not been recorded. The EIP-170 assertions were also redundant and rejected the valid equality boundary.

## Impact

The production behavior change is confined to Deleverage's basic Underscore earn-vault preflight path: amounts that BasicVault would clamp to a zero-safe-conversion token balance are soft-skipped before withdrawal instead of reverting after state mutation. Other AuctionHouse withdrawal paths continue to pass the preflight flag as `False`.

Measured deployed runtime sizes at this revision:

- Deleverage: 24,553 bytes — 23 bytes EIP-170 headroom
- AuctionHouse: 24,469 bytes — 107 bytes EIP-170 headroom

## Validation

- `507 passed` — `tests/core/deleverage tests/config/test_switchboard_delta.py tests/core/auctionHouse`
- `32 passed` — `tests/priceSources/test_undy_vault_prices.py`
- five focused reviewer regressions passed
- four behavioral mutations were run independently and each was killed by its intended test
- `git diff --check` clean

This PR is based directly on `deleverage-updates` at `bb5475e`, so its diff is only the follow-up delta for PR #61.
