### PR TITLE
feat: add governance and stability vault pointers

### DIFF
--- a/contracts/config/SwitchboardAlpha.vy
+++ b/contracts/config/SwitchboardAlpha.vy
@@ -37,6 +37,7 @@ interface MissionControl:
     def isSupportedAsset(_asset: address) -> bool: view
     def rewardsConfig() -> cs.RipeRewardsConfig: view
     def genDebtConfig() -> cs.GenDebtConfig: view
+    def coreRipeGovVaultId() -> uint256: view
     def genConfig() -> cs.GenConfig: view
 
 interface VaultBook:
@@ -1368,6 +1369,7 @@ def setRipeGovVaultConfig(
     _missionControl: address = empty(address),
 ) -> uint256:
     assert gov._canGovern(msg.sender) # dev: no perms
+    mc: address = self._resolveMissionControl(_missionControl)
 
     lockTerms: cs.LockTerms = cs.LockTerms(
         minLockDuration=_minLockDuration,
@@ -1376,7 +1378,7 @@ def setRipeGovVaultConfig(
         canExit=_canExit,
         exitFee=_exitFee,
     )
-    assert self._isValidRipeVaultConfig(_asset, _assetWeight, lockTerms) # dev: invalid ripe vault config
+    assert self._isValidRipeVaultConfig(_asset, _assetWeight, lockTerms, mc) # dev: invalid ripe vault config
 
     aid: uint256 = timeLock._initiateAction()
     self.actionType[aid] = ActionType.RIPE_VAULT_CONFIG
@@ -1386,7 +1388,7 @@ def setRipeGovVaultConfig(
         shouldFreezeWhenBadDebt=_shouldFreezeWhenBadDebt,
         lockTerms=lockTerms,
     )
-    self.pendingMissionControl[aid] = self._resolveMissionControl(_missionControl)
+    self.pendingMissionControl[aid] = mc
 
     log PendingRipeGovVaultConfigChange(
         asset=_asset,
@@ -1405,16 +1407,17 @@ def setRipeGovVaultConfig(
 
 @view
 @internal
-def _isValidRipeVaultConfig(_asset: address, _assetWeight: uint256, _lockTerms: cs.LockTerms) -> bool:
+def _isValidRipeVaultConfig(_asset: address, _assetWeight: uint256, _lockTerms: cs.LockTerms, _missionControl: address) -> bool:
     if _asset == empty(address):
         return False
 
-    mc: address = self._getMissionControlAddr()
-    if not staticcall MissionControl(mc).isSupportedAsset(_asset):
+    if not staticcall MissionControl(_missionControl).isSupportedAsset(_asset):
         return False
 
-    # NOTE: this assumes that vault id 2 is ripe gov vault !!
-    if not staticcall MissionControl(mc).isSupportedAssetInVault(2, _asset):
+    coreRipeGovVaultId: uint256 = staticcall MissionControl(_missionControl).coreRipeGovVaultId()
+    if coreRipeGovVaultId == 0:
+        return False
+    if not staticcall MissionControl(_missionControl).isSupportedAssetInVault(coreRipeGovVaultId, _asset):
         return False
 
     if _assetWeight > 500_00: # max 500%

--- a/contracts/config/SwitchboardBravo.vy
+++ b/contracts/config/SwitchboardBravo.vy
@@ -28,6 +28,8 @@ interface MissionControl:
     def assetConfig(_asset: address) -> cs.AssetConfig: view
     def canPerformLiteAction(_user: address) -> bool: view
     def isSupportedAsset(_asset: address) -> bool: view
+    def preferredStabVaultId() -> uint256: view
+    def coreRipeGovVaultId() -> uint256: view
     def maxLtvDeviation() -> uint256: view
     def trainingWheels() -> address: view
 
@@ -246,7 +248,8 @@ def addAsset(
     _missionControl: address = empty(address),
 ) -> uint256:
     assert gov._canGovern(msg.sender) # dev: no perms
-    assert not staticcall MissionControl(self._resolveMissionControl(_missionControl)).isSupportedAsset(_asset) # dev: must be new asset
+    mc: address = self._resolveMissionControl(_missionControl)
+    assert not staticcall MissionControl(mc).isSupportedAsset(_asset) # dev: must be new asset
 
     customAuctionParams: cs.AuctionParams = empty(cs.AuctionParams)
     if _customAuctionParams.hasParams:
@@ -275,7 +278,7 @@ def addAsset(
         whitelist=_whitelist,
         isNft=_isNft,
     )
-    assert self._isValidAssetConfig(_asset, config) # dev: invalid asset
+    assert self._isValidAssetConfig(_asset, config, mc) # dev: invalid asset
 
     aid: uint256 = timeLock._initiateAction()
     self.actionType[aid] = ActionType.ASSET_ADD_NEW
@@ -322,12 +325,12 @@ def addAsset(
 
 @view
 @internal
-def _isValidAssetConfig(_asset: address, _config: cs.AssetConfig) -> bool:
+def _isValidAssetConfig(_asset: address, _config: cs.AssetConfig, _missionControl: address) -> bool:
     if _asset == empty(address):
         return False
     if not self._isValidDebtTerms(_config.debtTerms):
         return False
-    if not self._isValidAssetDepositParams(_asset, _config.vaultIds, _config.stakersPointsAlloc, _config.voterPointsAlloc, _config.perUserDepositLimit, _config.globalDepositLimit, _config.minDepositBalance):
+    if not self._isValidAssetDepositParams(_asset, _config.vaultIds, _config.stakersPointsAlloc, _config.voterPointsAlloc, _config.perUserDepositLimit, _config.globalDepositLimit, _config.minDepositBalance, _missionControl):
         return False
     if not self._isValidAssetLiqConfig(_asset, _config.shouldBurnAsPayment, _config.shouldTransferToEndaoment, _config.shouldSwapInStabPools, _config.shouldAuctionInstantly, _config.specialStabPoolId, _config.isNft, _config.whitelist, _config.debtTerms.ltv):
         return False
@@ -358,8 +361,9 @@ def setAssetDepositParams(
 ) -> uint256:
     assert gov._canGovern(msg.sender) # dev: no perms
 
-    assert staticcall MissionControl(self._resolveMissionControl(_missionControl)).isSupportedAsset(_asset) # dev: invalid asset
-    assert self._isValidAssetDepositParams(_asset, _vaultIds, _stakersPointsAlloc, _voterPointsAlloc, _perUserDepositLimit, _globalDepositLimit, _minDepositBalance) # dev: invalid asset deposit params
+    mc: address = self._resolveMissionControl(_missionControl)
+    assert staticcall MissionControl(mc).isSupportedAsset(_asset) # dev: invalid asset
+    assert self._isValidAssetDepositParams(_asset, _vaultIds, _stakersPointsAlloc, _voterPointsAlloc, _perUserDepositLimit, _globalDepositLimit, _minDepositBalance, mc) # dev: invalid asset deposit params
     return self._setPendingAssetConfig(ActionType.ASSET_DEPOSIT_PARAMS, _asset, _missionControl, _vaultIds, _stakersPointsAlloc, _voterPointsAlloc, _perUserDepositLimit, _globalDepositLimit, _minDepositBalance)
 
 
@@ -373,6 +377,7 @@ def _isValidAssetDepositParams(
     _perUserDepositLimit: uint256,
     _globalDepositLimit: uint256,
     _minDepositBalance: uint256,
+    _missionControl: address,
 ) -> bool:
     vaultBook: address = staticcall RipeHq(gov._getRipeHqFromGov()).getAddr(VAULT_BOOK_ID)
     if 0 in [_perUserDepositLimit, _globalDepositLimit]:
@@ -391,9 +396,12 @@ def _isValidAssetDepositParams(
     
     # staker allocs must be with staker vaults
     if _stakersPointsAlloc != 0:
+        preferredStabVaultId: uint256 = staticcall MissionControl(_missionControl).preferredStabVaultId()
+        coreRipeGovVaultId: uint256 = staticcall MissionControl(_missionControl).coreRipeGovVaultId()
+
         hasStakerVault: bool = False
-        for sid: uint256 in [1, 2]:
-            if sid in _vaultIds:
+        for sid: uint256 in [preferredStabVaultId, coreRipeGovVaultId]:
+            if sid != 0 and sid in _vaultIds:
                 hasStakerVault = True
                 break
         if not hasStakerVault:
@@ -747,7 +755,7 @@ def executePendingAction(_aid: uint256) -> bool:
 
     if actionType == ActionType.ASSET_ADD_NEW:
         p: AssetUpdate = self.pendingAssetConfig[_aid]
-        assert self._isValidAssetConfig(p.asset, p.config) # dev: invalid asset config
+        assert self._isValidAssetConfig(p.asset, p.config, mc) # dev: invalid asset config
         extcall MissionControl(mc).setAssetConfig(p.asset, p.config)
         log AssetAdded(asset=p.asset)
 
@@ -760,7 +768,7 @@ def executePendingAction(_aid: uint256) -> bool:
         config.perUserDepositLimit = p.config.perUserDepositLimit
         config.globalDepositLimit = p.config.globalDepositLimit
         config.minDepositBalance = p.config.minDepositBalance
-        assert self._isValidAssetConfig(p.asset, config) # dev: invalid asset config
+        assert self._isValidAssetConfig(p.asset, config, mc) # dev: invalid asset config
         extcall MissionControl(mc).setAssetConfig(p.asset, config)
         log AssetDepositParamsSet(asset=p.asset, numVaultIds=len(p.config.vaultIds), stakersPointsAlloc=p.config.stakersPointsAlloc, voterPointsAlloc=p.config.voterPointsAlloc, perUserDepositLimit=p.config.perUserDepositLimit, globalDepositLimit=p.config.globalDepositLimit, minDepositBalance=p.config.minDepositBalance)
 
@@ -773,7 +781,7 @@ def executePendingAction(_aid: uint256) -> bool:
         config.shouldAuctionInstantly = p.config.shouldAuctionInstantly
         config.specialStabPoolId = p.config.specialStabPoolId
         config.customAuctionParams = p.config.customAuctionParams
-        assert self._isValidAssetConfig(p.asset, config) # dev: invalid asset config
+        assert self._isValidAssetConfig(p.asset, config, mc) # dev: invalid asset config
         extcall MissionControl(mc).setAssetConfig(p.asset, config)
         log AssetLiqConfigSet(asset=p.asset, shouldBurnAsPayment=p.config.shouldBurnAsPayment, shouldTransferToEndaoment=p.config.shouldTransferToEndaoment, shouldSwapInStabPools=p.config.shouldSwapInStabPools, shouldAuctionInstantly=p.config.shouldAuctionInstantly, specialStabPoolId=p.config.specialStabPoolId, auctionStartDiscount=p.config.customAuctionParams.startDiscount, auctionMaxDiscount=p.config.customAuctionParams.maxDiscount, auctionDelay=p.config.customAuctionParams.delay, auctionDuration=p.config.customAuctionParams.duration)
 
@@ -781,7 +789,7 @@ def executePendingAction(_aid: uint256) -> bool:
         p: AssetUpdate = self.pendingAssetConfig[_aid]
         config: cs.AssetConfig = staticcall MissionControl(mc).assetConfig(p.asset)
         config.debtTerms = p.config.debtTerms
-        assert self._isValidAssetConfig(p.asset, config) # dev: invalid asset config
+        assert self._isValidAssetConfig(p.asset, config, mc) # dev: invalid asset config
         extcall MissionControl(mc).setAssetConfig(p.asset, config)
         log AssetDebtTermsSet(asset=p.asset, ltv=p.config.debtTerms.ltv, redemptionThreshold=p.config.debtTerms.redemptionThreshold, liqThreshold=p.config.debtTerms.liqThreshold, liqFee=p.config.debtTerms.liqFee, borrowRate=p.config.debtTerms.borrowRate, daowry=p.config.debtTerms.daowry)
 
@@ -789,7 +797,7 @@ def executePendingAction(_aid: uint256) -> bool:
         p: AssetUpdate = self.pendingAssetConfig[_aid]
         config: cs.AssetConfig = staticcall MissionControl(mc).assetConfig(p.asset)
         config.whitelist = p.config.whitelist
-        assert self._isValidAssetConfig(p.asset, config) # dev: invalid asset config
+        assert self._isValidAssetConfig(p.asset, config, mc) # dev: invalid asset config
         extcall MissionControl(mc).setAssetConfig(p.asset, config)
         log WhitelistAssetSet(asset=p.asset, whitelist=p.config.whitelist)
 

--- a/contracts/config/SwitchboardCharlie.vy
+++ b/contracts/config/SwitchboardCharlie.vy
@@ -38,12 +38,25 @@ interface Lootbox:
 interface MissionControl:
     def setUserDelegation(_user: address, _delegate: address, _config: cs.ActionDelegation): nonpayable
     def setAssetConfig(_asset: address, _assetConfig: cs.AssetConfig): nonpayable
+    def isSupportedAssetInVault(_vaultId: uint256, _asset: address) -> bool: view
     def setUserConfig(_user: address, _config: cs.UserConfig): nonpayable
     def setTrainingWheels(_trainingWheels: address): nonpayable
+    def setPreferredStabVaultId(_vaultId: uint256): nonpayable
+    def setCoreRipeGovVaultId(_vaultId: uint256): nonpayable
     def deregisterAsset(_asset: address) -> bool: nonpayable
     def assetConfig(_asset: address) -> cs.AssetConfig: view
     def canPerformLiteAction(_user: address) -> bool: view
     def isSupportedAsset(_asset: address) -> bool: view
+    def preferredStabVaultId() -> uint256: view
+    def coreRipeGovVaultId() -> uint256: view
+
+interface RipeGovVault:
+    def totalGovPoints() -> uint256: view
+    def isPaused() -> bool: view
+
+interface StabilityPool:
+    def totalClaimableBalances(_asset: address) -> uint256: view
+    def isPaused() -> bool: view
 
 interface AuctionHouse:
     def startManyAuctions(_auctions: DynArray[FungAuctionConfig, MAX_AUCTIONS], _a: addys.Addys = empty(addys.Addys)) -> uint256: nonpayable
@@ -74,6 +87,7 @@ interface VaultData:
     def deregisterVaultAsset(_asset: address) -> bool: nonpayable
 
 interface VaultBook:
+    def isValidRegId(_regId: uint256) -> bool: view
     def getAddr(_vaultId: uint256) -> address: view
 
 interface RipeHq:
@@ -94,6 +108,8 @@ flag ActionType:
     DEREGISTER_VAULT_ASSET
     SET_USER_CONFIG
     SET_USER_DELEGATION
+    CORE_RIPE_GOV_VAULT
+    PREFERRED_STAB_VAULT
 
 flag AssetFlag:
     CAN_DEPOSIT
@@ -376,6 +392,30 @@ event UserDelegationSet:
     delegate: indexed(address)
     caller: indexed(address)
 
+event PendingCoreRipeGovVaultIdChange:
+    previousVaultId: uint256
+    newVaultId: uint256
+    newVaultAddr: address
+    confirmationBlock: uint256
+    actionId: uint256
+
+event CoreRipeGovVaultIdSet:
+    previousVaultId: uint256
+    newVaultId: uint256
+    newVaultAddr: address
+
+event PendingPreferredStabVaultIdChange:
+    previousVaultId: uint256
+    newVaultId: uint256
+    newVaultAddr: address
+    confirmationBlock: uint256
+    actionId: uint256
+
+event PreferredStabVaultIdSet:
+    previousVaultId: uint256
+    newVaultId: uint256
+    newVaultAddr: address
+
 # pending actions storage
 actionType: public(HashMap[uint256, ActionType])
 pendingRecoverFundsActions: public(HashMap[uint256, RecoverFundsAction])
@@ -393,6 +433,8 @@ pendingDeregisterAsset: public(HashMap[uint256, address])
 pendingDeregisterVaultAsset: public(HashMap[uint256, DeregisterVaultAssetAction])
 pendingUserConfig: public(HashMap[uint256, UserConfigAction])
 pendingUserDelegation: public(HashMap[uint256, UserDelegationAction])
+pendingCoreRipeGovVaultId: public(HashMap[uint256, uint256])
+pendingPreferredStabVaultId: public(HashMap[uint256, uint256])
 
 MAX_RECOVER_ASSETS: constant(uint256) = 20
 MAX_AUCTIONS: constant(uint256) = 20
@@ -400,6 +442,8 @@ MAX_TRAINING_WHEEL_ACCESS: constant(uint256) = 25
 MAX_DEBT_UPDATES: constant(uint256) = 50
 MAX_CLAIM_USERS: constant(uint256) = 50
 
+SAVINGS_GREEN_ID: constant(uint256) = 2
+RIPE_TOKEN_ID: constant(uint256) = 3
 LEDGER_ID: constant(uint256) = 4
 MISSION_CONTROL_ID: constant(uint256) = 5
 SWITCHBOARD_ID: constant(uint256) = 6
@@ -480,6 +524,101 @@ def _getVaultBookAddr() -> address:
 @internal
 def _getLedgerAddr() -> address:
     return staticcall RipeHq(gov._getRipeHqFromGov()).getAddr(LEDGER_ID)
+
+
+##########################
+# Core Vault ID Pointers #
+##########################
+
+
+@view
+@internal
+def _validateCoreRipeGovVaultId(_vaultId: uint256, _missionControl: address) -> (address, uint256):
+    assert _vaultId != 0 # dev: invalid vault id
+
+    vaultBook: address = self._getVaultBookAddr()
+    assert staticcall VaultBook(vaultBook).isValidRegId(_vaultId) # dev: invalid vault id
+    vaultAddr: address = staticcall VaultBook(vaultBook).getAddr(_vaultId)
+    assert vaultAddr != empty(address) and vaultAddr.is_contract # dev: invalid vault
+    previousVaultId: uint256 = staticcall MissionControl(_missionControl).coreRipeGovVaultId()
+    assert _vaultId != previousVaultId # dev: already set
+
+    ripeToken: address = staticcall RipeHq(gov._getRipeHqFromGov()).getAddr(RIPE_TOKEN_ID)
+    assert staticcall MissionControl(_missionControl).isSupportedAssetInVault(_vaultId, ripeToken) # dev: unsupported asset
+    na: uint256 = staticcall RipeGovVault(vaultAddr).totalGovPoints()
+    assert not staticcall RipeGovVault(vaultAddr).isPaused() # dev: vault paused
+    return vaultAddr, previousVaultId
+
+
+@view
+@internal
+def _validatePreferredStabVaultId(_vaultId: uint256, _missionControl: address) -> (address, uint256):
+    assert _vaultId != 0 # dev: invalid vault id
+
+    vaultBook: address = self._getVaultBookAddr()
+    assert staticcall VaultBook(vaultBook).isValidRegId(_vaultId) # dev: invalid vault id
+    vaultAddr: address = staticcall VaultBook(vaultBook).getAddr(_vaultId)
+    assert vaultAddr != empty(address) and vaultAddr.is_contract # dev: invalid vault
+    previousVaultId: uint256 = staticcall MissionControl(_missionControl).preferredStabVaultId()
+    assert _vaultId != previousVaultId # dev: already set
+
+    savingsGreen: address = staticcall RipeHq(gov._getRipeHqFromGov()).getAddr(SAVINGS_GREEN_ID)
+    assert staticcall MissionControl(_missionControl).isSupportedAssetInVault(_vaultId, savingsGreen) # dev: unsupported asset
+    na: uint256 = staticcall StabilityPool(vaultAddr).totalClaimableBalances(savingsGreen)
+    assert not staticcall StabilityPool(vaultAddr).isPaused() # dev: vault paused
+    return vaultAddr, previousVaultId
+
+
+@external
+def setCoreRipeGovVaultId(
+    _newVaultId: uint256,
+    _missionControl: address = empty(address),
+) -> uint256:
+    assert gov._canGovern(msg.sender) # dev: no perms
+
+    mc: address = self._resolveMissionControl(_missionControl)
+    newVaultAddr: address = empty(address)
+    previousVaultId: uint256 = 0
+    newVaultAddr, previousVaultId = self._validateCoreRipeGovVaultId(_newVaultId, mc)
+
+    aid: uint256 = timeLock._initiateAction()
+    self.actionType[aid] = ActionType.CORE_RIPE_GOV_VAULT
+    self.pendingCoreRipeGovVaultId[aid] = _newVaultId
+    self.pendingMissionControl[aid] = mc
+    log PendingCoreRipeGovVaultIdChange(
+        previousVaultId=previousVaultId,
+        newVaultId=_newVaultId,
+        newVaultAddr=newVaultAddr,
+        confirmationBlock=timeLock._getActionConfirmationBlock(aid),
+        actionId=aid,
+    )
+    return aid
+
+
+@external
+def setPreferredStabVaultId(
+    _newVaultId: uint256,
+    _missionControl: address = empty(address),
+) -> uint256:
+    assert gov._canGovern(msg.sender) # dev: no perms
+
+    mc: address = self._resolveMissionControl(_missionControl)
+    newVaultAddr: address = empty(address)
+    previousVaultId: uint256 = 0
+    newVaultAddr, previousVaultId = self._validatePreferredStabVaultId(_newVaultId, mc)
+
+    aid: uint256 = timeLock._initiateAction()
+    self.actionType[aid] = ActionType.PREFERRED_STAB_VAULT
+    self.pendingPreferredStabVaultId[aid] = _newVaultId
+    self.pendingMissionControl[aid] = mc
+    log PendingPreferredStabVaultIdChange(
+        previousVaultId=previousVaultId,
+        newVaultId=_newVaultId,
+        newVaultAddr=newVaultAddr,
+        confirmationBlock=timeLock._getActionConfirmationBlock(aid),
+        actionId=aid,
+    )
+    return aid
 
 
 #################
@@ -1037,6 +1176,28 @@ def executePendingAction(_aid: uint256) -> bool:
             mc = self._getMissionControlAddr()
         extcall MissionControl(mc).setTrainingWheels(p)
         log TrainingWheelsSet(trainingWheels=p)
+
+    elif actionType == ActionType.CORE_RIPE_GOV_VAULT:
+        newVaultId: uint256 = self.pendingCoreRipeGovVaultId[_aid]
+        mc: address = self.pendingMissionControl[_aid]
+        if mc == empty(address):
+            mc = self._getMissionControlAddr()
+        newVaultAddr: address = empty(address)
+        previousVaultId: uint256 = 0
+        newVaultAddr, previousVaultId = self._validateCoreRipeGovVaultId(newVaultId, mc)
+        extcall MissionControl(mc).setCoreRipeGovVaultId(newVaultId)
+        log CoreRipeGovVaultIdSet(previousVaultId=previousVaultId, newVaultId=newVaultId, newVaultAddr=newVaultAddr)
+
+    elif actionType == ActionType.PREFERRED_STAB_VAULT:
+        newVaultId: uint256 = self.pendingPreferredStabVaultId[_aid]
+        mc: address = self.pendingMissionControl[_aid]
+        if mc == empty(address):
+            mc = self._getMissionControlAddr()
+        newVaultAddr: address = empty(address)
+        previousVaultId: uint256 = 0
+        newVaultAddr, previousVaultId = self._validatePreferredStabVaultId(newVaultId, mc)
+        extcall MissionControl(mc).setPreferredStabVaultId(newVaultId)
+        log PreferredStabVaultIdSet(previousVaultId=previousVaultId, newVaultId=newVaultId, newVaultAddr=newVaultAddr)
 
     elif actionType == ActionType.DEREGISTER_ASSET:
         asset: address = self.pendingDeregisterAsset[_aid]

--- a/contracts/core/BondRoom.vy
+++ b/contracts/core/BondRoom.vy
@@ -54,6 +54,7 @@ interface PriceDesk:
 
 interface MissionControl:
     def getPurchaseRipeBondConfig(_user: address) -> PurchaseRipeBondConfig: view
+    def coreRipeGovVaultId() -> uint256: view
 
 interface RipeToken:
     def mint(_to: address, _amount: uint256): nonpayable
@@ -99,7 +100,6 @@ event BondBoosterSet:
     bondBooster: address
 
 HUNDRED_PERCENT: constant(uint256) = 100_00 # 100.00%
-RIPE_GOV_VAULT_ID: constant(uint256) = 2
 
 bondBooster: public(address)
 
@@ -218,9 +218,11 @@ def purchaseRipeBond(
 
     # mint ripe tokens, deposit into gov vault or transfer tokens to user
     if lockDuration != 0:
+        coreRipeGovVaultId: uint256 = staticcall MissionControl(a.missionControl).coreRipeGovVaultId()
+        assert coreRipeGovVaultId != 0 # dev: invalid vault id
         extcall RipeToken(a.ripeToken).mint(self, totalRipePayout)
         assert extcall IERC20(a.ripeToken).approve(a.teller, totalRipePayout, default_return_value=True) # dev: ripe approval failed
-        extcall Teller(a.teller).depositFromTrusted(_recipient, RIPE_GOV_VAULT_ID, a.ripeToken, totalRipePayout, lockDuration, a)
+        extcall Teller(a.teller).depositFromTrusted(_recipient, coreRipeGovVaultId, a.ripeToken, totalRipePayout, lockDuration, a)
         assert extcall IERC20(a.ripeToken).approve(a.teller, 0, default_return_value=True) # dev: ripe approval failed
     else:
         extcall RipeToken(a.ripeToken).mint(_recipient, totalRipePayout)

--- a/contracts/core/CreditEngine.vy
+++ b/contracts/core/CreditEngine.vy
@@ -52,6 +52,7 @@ interface MissionControl:
     def getDynamicBorrowRateConfig() -> DynamicBorrowRateConfig: view
     def getRepayConfig(_user: address) -> RepayConfig: view
     def getDebtTerms(_asset: address) -> cs.DebtTerms: view
+    def preferredStabVaultId() -> uint256: view
     def underscoreRegistry() -> address: view
 
 interface Teller:
@@ -1205,8 +1206,10 @@ def _handleGreenForUser(
 
         # put sGREEN into stability pool
         if _shouldEnterStabPool:
+            preferredStabVaultId: uint256 = staticcall MissionControl(_a.missionControl).preferredStabVaultId()
+            assert preferredStabVaultId != 0 # dev: invalid vault id
             assert extcall IERC20(_a.savingsGreen).approve(_a.teller, sGreenAmount, default_return_value=True) # dev: sgreen approval failed
-            extcall Teller(_a.teller).depositFromTrusted(_recipient, STABILITY_POOL_ID, _a.savingsGreen, sGreenAmount, 0, _a)
+            extcall Teller(_a.teller).depositFromTrusted(_recipient, preferredStabVaultId, _a.savingsGreen, sGreenAmount, 0, _a)
             assert extcall IERC20(_a.savingsGreen).approve(_a.teller, 0, default_return_value=True) # dev: sgreen approval failed
 
     else:

--- a/contracts/core/CreditRedeem.vy
+++ b/contracts/core/CreditRedeem.vy
@@ -42,6 +42,7 @@ interface CreditEngine:
 
 interface MissionControl:
     def getRedeemCollateralConfig(_asset: address, _recipient: address) -> RedeemCollateralConfig: view
+    def preferredStabVaultId() -> uint256: view
     def getLtvPaybackBuffer() -> uint256: view
     def underscoreRegistry() -> address: view
 
@@ -107,7 +108,6 @@ event CollateralRedeemed:
 
 HUNDRED_PERCENT: constant(uint256) = 100_00 # 100.00%
 MAX_COLLATERAL_REDEMPTIONS: constant(uint256) = 20
-STABILITY_POOL_ID: constant(uint256) = 1
 UNDERSCORE_VAULT_REGISTRY_ID: constant(uint256) = 10
 
 
@@ -289,8 +289,10 @@ def _handleGreenForUser(
 
         # put sGREEN into stability pool
         if _shouldEnterStabPool:
+            preferredStabVaultId: uint256 = staticcall MissionControl(_a.missionControl).preferredStabVaultId()
+            assert preferredStabVaultId != 0 # dev: invalid vault id
             assert extcall IERC20(_a.savingsGreen).approve(_a.teller, sGreenAmount, default_return_value=True) # dev: sgreen approval failed
-            extcall Teller(_a.teller).depositFromTrusted(_recipient, STABILITY_POOL_ID, _a.savingsGreen, sGreenAmount, 0, _a)
+            extcall Teller(_a.teller).depositFromTrusted(_recipient, preferredStabVaultId, _a.savingsGreen, sGreenAmount, 0, _a)
             assert extcall IERC20(_a.savingsGreen).approve(_a.teller, 0, default_return_value=True) # dev: sgreen approval failed
 
     else:

--- a/contracts/core/HumanResources.vy
+++ b/contracts/core/HumanResources.vy
@@ -73,6 +73,7 @@ interface VaultBook:
     def getAddr(_vaultId: uint256) -> address: view
 
 interface MissionControl:
+    def coreRipeGovVaultId() -> uint256: view
     def hrConfig() -> cs.HrConfig: view
 
 struct ContributorTerms:
@@ -124,8 +125,6 @@ event NewContributorCancelled:
 # pending
 pendingContributor: public(HashMap[uint256, ContributorTerms]) # aid -> terms
 
-RIPE_GOV_VAULT_ID: constant(uint256) = 2
-
 
 @deploy
 def __init__(
@@ -137,6 +136,19 @@ def __init__(
     deptBasics.__init__(False, False, True) # can mint ripe only
     gov.__init__(_ripeHq, empty(address), 0, 0, 0)
     timeLock.__init__(_minConfigTimeLock, _maxConfigTimeLock, 0, _maxConfigTimeLock)
+
+
+####################
+# Vault ID Pointer #
+####################
+
+
+@view
+@internal
+def _getCoreRipeGovVaultId(_missionControl: address) -> uint256:
+    vaultId: uint256 = staticcall MissionControl(_missionControl).coreRipeGovVaultId()
+    assert vaultId != 0 # dev: invalid vault id
+    return vaultId
 
 
 ####################
@@ -386,7 +398,8 @@ def canModifyHrContributor(_addr: address) -> bool:
 @external
 def hasRipeBalance(_contributor: address) -> bool:
     a: addys.Addys = addys._getAddys()
-    ripeGovVaultAddr: address = staticcall VaultBook(a.vaultBook).getAddr(RIPE_GOV_VAULT_ID) 
+    vaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+    ripeGovVaultAddr: address = staticcall VaultBook(a.vaultBook).getAddr(vaultId)
     return staticcall Vault(ripeGovVaultAddr).doesUserHaveBalance(_contributor, a.ripeToken)
 
 
@@ -400,7 +413,7 @@ def transferContributorRipeTokens(_owner: address, _lockDuration: uint256) -> ui
     assert staticcall Ledger(a.ledger).isHrContributor(msg.sender) # dev: not a contributor
 
     # transfer tokens in ripe gov vault
-    vaultId: uint256 = RIPE_GOV_VAULT_ID
+    vaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
     ripeGovVaultAddr: address = staticcall VaultBook(a.vaultBook).getAddr(vaultId) 
     amount: uint256 = extcall RipeGovVault(ripeGovVaultAddr).transferContributorRipeTokens(msg.sender, _owner, _lockDuration, a)
 
@@ -423,7 +436,8 @@ def cashRipeCheck(_amount: uint256, _lockDuration: uint256) -> bool:
 
     # deposit into gov vault
     assert extcall IERC20(a.ripeToken).approve(a.teller, _amount, default_return_value=True) # dev: ripe approval failed
-    extcall Teller(a.teller).depositFromTrusted(msg.sender, RIPE_GOV_VAULT_ID, a.ripeToken, _amount, _lockDuration, a)
+    vaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+    extcall Teller(a.teller).depositFromTrusted(msg.sender, vaultId, a.ripeToken, _amount, _lockDuration, a)
     assert extcall IERC20(a.ripeToken).approve(a.teller, 0, default_return_value=True) # dev: ripe approval failed
     return True
 
@@ -444,7 +458,8 @@ def refundAfterCancelPaycheck(_amount: uint256, _shouldBurnPosition: bool):
         return
 
     # withdraw and burn position
-    ripeGovVaultAddr: address = staticcall VaultBook(a.vaultBook).getAddr(RIPE_GOV_VAULT_ID)
+    vaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+    ripeGovVaultAddr: address = staticcall VaultBook(a.vaultBook).getAddr(vaultId)
     withdrawalAmount: uint256 = extcall RipeGovVault(ripeGovVaultAddr).withdrawContributorTokensToBurn(msg.sender, a)
     burnAmount: uint256 = min(withdrawalAmount, staticcall IERC20(a.ripeToken).balanceOf(self))
     if burnAmount != 0:

--- a/contracts/core/Lootbox.vy
+++ b/contracts/core/Lootbox.vy
@@ -53,6 +53,7 @@ interface MissionControl:
     def getClaimLootConfig(_user: address, _caller: address, _ripeToken: address) -> ClaimLootConfig: view
     def getDepositPointsConfig(_asset: address) -> DepositPointsConfig: view
     def getRewardsConfig() -> RewardsConfig: view
+    def coreRipeGovVaultId() -> uint256: view
     def underscoreRegistry() -> address: view
 
 interface Teller:
@@ -189,7 +190,6 @@ HUNDRED_PERCENT: constant(uint256) = 100_00 # 100.00%
 MAX_ASSETS_TO_CLEAN: constant(uint256) = 20
 MAX_VAULTS_TO_CLEAN: constant(uint256) = 10
 MAX_CLAIM_USERS: constant(uint256) = 25
-RIPE_GOV_VAULT_ID: constant(uint256) = 2
 MIN_UNDERSCORE_SEND_INTERVAL: immutable(uint256)
 
 
@@ -213,6 +213,19 @@ def __init__(
         self.undyDepositRewardsAmount = _undyDepositRewardsAmount
         self.undyYieldBonusAmount = _undyYieldBonusAmount
         self.hasUnderscoreRewards = True
+
+
+####################
+# Vault ID Pointer #
+####################
+
+
+@view
+@internal
+def _getCoreRipeGovVaultId(_missionControl: address) -> uint256:
+    vaultId: uint256 = staticcall MissionControl(_missionControl).coreRipeGovVaultId()
+    assert vaultId != 0 # dev: invalid vault id
+    return vaultId
 
 
 ##############
@@ -288,6 +301,7 @@ def _claimLoot(
     if numUserVaults == 0:
         return totalRipeForUser
 
+    coreRipeGovVaultId: uint256 = self._getCoreRipeGovVaultId(_a.missionControl)
     for i: uint256 in range(1, numUserVaults, bound=max_value(uint256)):
         vaultId: uint256 = staticcall Ledger(_a.ledger).userVaults(_user, i)
         vaultAddr: address = staticcall AddressRegistry(_a.vaultBook).getAddr(vaultId)
@@ -308,7 +322,7 @@ def _claimLoot(
                 assetsToRemove.append(asset)
 
             # claim loot
-            totalRipeForUser += self._claimDepositLoot(_user, vaultId, vaultAddr, asset, not hasBalance, _a)
+            totalRipeForUser += self._claimDepositLoot(_user, vaultId, vaultAddr, asset, not hasBalance, coreRipeGovVaultId, _a)
 
         # clean up user assets (storage optimization)
         stillInVault: bool = self._cleanUpUserAssets(_user, vaultAddr, assetsToRemove)
@@ -320,7 +334,7 @@ def _claimLoot(
 
     # mint ripe, then stake or transfer to user
     if totalRipeForUser != 0:
-        self._handleRipeMint(_user, totalRipeForUser, _shouldStake, config, _a)
+        self._handleRipeMint(_user, totalRipeForUser, _shouldStake, config, coreRipeGovVaultId, _a)
 
     return totalRipeForUser
 
@@ -341,6 +355,7 @@ def getClaimableLoot(_user: address) -> uint256:
     if numUserVaults == 0:
         return totalRipeForUser
 
+    coreRipeGovVaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
     for i: uint256 in range(1, numUserVaults, bound=max_value(uint256)):
         vaultId: uint256 = staticcall Ledger(a.ledger).userVaults(_user, i)
         vaultAddr: address = staticcall AddressRegistry(a.vaultBook).getAddr(vaultId)
@@ -351,7 +366,7 @@ def getClaimableLoot(_user: address) -> uint256:
             asset: address = staticcall Vault(vaultAddr).userAssets(_user, y)
             if asset == empty(address):
                 continue
-            totalRipeForUser += self._getClaimableDepositLootForAsset(_user, vaultId, vaultAddr, asset, a)
+            totalRipeForUser += self._getClaimableDepositLootForAsset(_user, vaultId, vaultAddr, asset, coreRipeGovVaultId, a)
 
     return totalRipeForUser
 
@@ -370,10 +385,11 @@ def claimDepositLootForAsset(_user: address, _vaultId: uint256, _asset: address)
     assert not deptBasics.isPaused # dev: contract paused
     a: addys.Addys = addys._getAddys()
     vaultAddr: address = staticcall AddressRegistry(a.vaultBook).getAddr(_vaultId)
-    totalRipeForUser: uint256 = self._claimDepositLoot(_user, _vaultId, vaultAddr, _asset, False, a)
+    coreRipeGovVaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+    totalRipeForUser: uint256 = self._claimDepositLoot(_user, _vaultId, vaultAddr, _asset, False, coreRipeGovVaultId, a)
     if totalRipeForUser != 0:
         config: ClaimLootConfig = staticcall MissionControl(a.missionControl).getClaimLootConfig(_user, _user, a.ripeToken)
-        self._handleRipeMint(_user, totalRipeForUser, False, config, a)
+        self._handleRipeMint(_user, totalRipeForUser, False, config, coreRipeGovVaultId, a)
     return totalRipeForUser
 
 
@@ -384,6 +400,7 @@ def _claimDepositLoot(
     _vaultAddr: address,
     _asset: address,
     _shouldFlush: bool,
+    _coreRipeGovVaultId: uint256,
     _a: addys.Addys,
 ) -> uint256:
     userRipeRewards: UserDepositLoot = empty(UserDepositLoot)
@@ -391,7 +408,7 @@ def _claimDepositLoot(
     ap: AssetDepositPoints = empty(AssetDepositPoints)
     gp: GlobalDepositPoints = empty(GlobalDepositPoints)
     globalRipeRewards: RipeRewards = empty(RipeRewards)
-    userRipeRewards, up, ap, gp, globalRipeRewards = self._getDepositLootData(_user, _vaultId, _vaultAddr, _asset, _shouldFlush, _a)
+    userRipeRewards, up, ap, gp, globalRipeRewards = self._getDepositLootData(_user, _vaultId, _vaultAddr, _asset, _shouldFlush, _coreRipeGovVaultId, _a)
 
     totalRipeForUser: uint256 = userRipeRewards.ripeStakerLoot + userRipeRewards.ripeVoteLoot + userRipeRewards.ripeGenLoot
     extcall Ledger(_a.ledger).setDepositPointsAndRipeRewards(_user, _vaultId, _asset, up, ap, gp, globalRipeRewards)
@@ -411,6 +428,7 @@ def _getDepositLootData(
     _vaultAddr: address,
     _asset: address,
     _shouldFlush: bool,
+    _coreRipeGovVaultId: uint256,
     _a: addys.Addys,
 ) -> (UserDepositLoot, UserDepositPoints, AssetDepositPoints, GlobalDepositPoints, RipeRewards):
 
@@ -422,7 +440,7 @@ def _getDepositLootData(
     up: UserDepositPoints = empty(UserDepositPoints)
     ap: AssetDepositPoints = empty(AssetDepositPoints)
     gp: GlobalDepositPoints = empty(GlobalDepositPoints)
-    up, ap, gp = self._getLatestDepositPoints(_user, _vaultId, _vaultAddr, _asset, config, _a)
+    up, ap, gp = self._getLatestDepositPoints(_user, _vaultId, _vaultAddr, _asset, config, _coreRipeGovVaultId, _a)
 
     # user has no points
     if up.balancePoints == 0:
@@ -466,7 +484,8 @@ def _getDepositLootData(
 def getClaimableDepositLootForAsset(_user: address, _vaultId: uint256, _asset: address) -> uint256:
     a: addys.Addys = addys._getAddys()
     vaultAddr: address = staticcall AddressRegistry(a.vaultBook).getAddr(_vaultId)
-    return self._getClaimableDepositLootForAsset(_user, _vaultId, vaultAddr, _asset, a)
+    coreRipeGovVaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+    return self._getClaimableDepositLootForAsset(_user, _vaultId, vaultAddr, _asset, coreRipeGovVaultId, a)
 
 
 @view
@@ -476,6 +495,7 @@ def _getClaimableDepositLootForAsset(
     _vaultId: uint256,
     _vaultAddr: address,
     _asset: address,
+    _coreRipeGovVaultId: uint256,
     _a: addys.Addys,
 ) -> uint256:
     userRipeRewards: UserDepositLoot = empty(UserDepositLoot)
@@ -483,7 +503,7 @@ def _getClaimableDepositLootForAsset(
     ap: AssetDepositPoints = empty(AssetDepositPoints)
     gp: GlobalDepositPoints = empty(GlobalDepositPoints)
     globalRipeRewards: RipeRewards = empty(RipeRewards)
-    userRipeRewards, up, ap, gp, globalRipeRewards = self._getDepositLootData(_user, _vaultId, _vaultAddr, _asset, False, _a)
+    userRipeRewards, up, ap, gp, globalRipeRewards = self._getDepositLootData(_user, _vaultId, _vaultAddr, _asset, False, _coreRipeGovVaultId, _a)
     return userRipeRewards.ripeStakerLoot + userRipeRewards.ripeVoteLoot + userRipeRewards.ripeGenLoot
     
 
@@ -578,7 +598,8 @@ def updateDepositPoints(
     up: UserDepositPoints = empty(UserDepositPoints)
     ap: AssetDepositPoints = empty(AssetDepositPoints)
     gp: GlobalDepositPoints = empty(GlobalDepositPoints)
-    up, ap, gp = self._getLatestDepositPoints(_user, _vaultId, _vaultAddr, _asset, config, a)
+    coreRipeGovVaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+    up, ap, gp = self._getLatestDepositPoints(_user, _vaultId, _vaultAddr, _asset, config, coreRipeGovVaultId, a)
 
     # update points
     extcall Ledger(a.ledger).setDepositPointsAndRipeRewards(_user, _vaultId, _asset, up, ap, gp, globalRewards)
@@ -604,7 +625,8 @@ def resetUserBalancePoints(_user: address, _asset: address, _vaultId: uint256):
     up: UserDepositPoints = empty(UserDepositPoints)
     ap: AssetDepositPoints = empty(AssetDepositPoints)
     gp: GlobalDepositPoints = empty(GlobalDepositPoints)
-    up, ap, gp = self._getLatestDepositPoints(_user, _vaultId, vaultAddr, _asset, config, a)
+    coreRipeGovVaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+    up, ap, gp = self._getLatestDepositPoints(_user, _vaultId, vaultAddr, _asset, config, coreRipeGovVaultId, a)
 
     # reset user balance points
     ap.balancePoints -= min(up.balancePoints, ap.balancePoints)
@@ -634,7 +656,8 @@ def resetAssetPoints(_asset: address, _vaultId: uint256):
     up: UserDepositPoints = empty(UserDepositPoints)
     ap: AssetDepositPoints = empty(AssetDepositPoints)
     gp: GlobalDepositPoints = empty(GlobalDepositPoints)
-    up, ap, gp = self._getLatestDepositPoints(empty(address), _vaultId, vaultAddr, _asset, config, a)
+    coreRipeGovVaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+    up, ap, gp = self._getLatestDepositPoints(empty(address), _vaultId, vaultAddr, _asset, config, coreRipeGovVaultId, a)
 
     # reset asset points
     gp.ripeStakerPoints -= min(ap.ripeStakerPoints, gp.ripeStakerPoints)
@@ -766,7 +789,8 @@ def getLatestDepositPoints(
     a: addys.Addys = addys._getAddys(_a)
     c: RewardsConfig = staticcall MissionControl(a.missionControl).getRewardsConfig()
     vaultAddr: address = staticcall AddressRegistry(a.vaultBook).getAddr(_vaultId)
-    return self._getLatestDepositPoints(_user, _vaultId, vaultAddr, _asset, c, a)
+    coreRipeGovVaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+    return self._getLatestDepositPoints(_user, _vaultId, vaultAddr, _asset, c, coreRipeGovVaultId, a)
 
 
 @view
@@ -777,8 +801,10 @@ def _getLatestDepositPoints(
     _vaultAddr: address,
     _asset: address,
     _c: RewardsConfig,
+    _coreRipeGovVaultId: uint256,
     _a: addys.Addys,
 ) -> (UserDepositPoints, AssetDepositPoints, GlobalDepositPoints):
+    assert _coreRipeGovVaultId != 0 # dev: invalid vault id
     p: DepositPointsBundle = staticcall Ledger(_a.ledger).getDepositPointsBundle(_user, _vaultId, _asset)
 
     # latest global points
@@ -810,7 +836,7 @@ def _getLatestDepositPoints(
 
     # get user loot share
     userLootShare: uint256 = staticcall Vault(_vaultAddr).getUserLootBoxShare(_user, _asset)
-    if userLootShare != 0 and _vaultId != 2: # skip for Ripe Gov Vault
+    if userLootShare != 0 and _vaultId != _coreRipeGovVaultId: # skip for Ripe Gov Vault
         userLootShare = userLootShare // assetPoints.precision
 
     # update `lastBalance`
@@ -992,7 +1018,8 @@ def claimBorrowLoot(_user: address) -> uint256:
     totalRipeForUser: uint256 = self._claimBorrowLoot(_user, a)
     if totalRipeForUser != 0:
         config: ClaimLootConfig = staticcall MissionControl(a.missionControl).getClaimLootConfig(_user, _user, a.ripeToken)
-        self._handleRipeMint(_user, totalRipeForUser, False, config, a)
+        coreRipeGovVaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+        self._handleRipeMint(_user, totalRipeForUser, False, config, coreRipeGovVaultId, a)
     return totalRipeForUser
 
 
@@ -1137,8 +1164,11 @@ def _handleRipeMint(
     _amount: uint256,
     _shouldStake: bool,
     _config: ClaimLootConfig,
+    _coreRipeGovVaultId: uint256,
     _a: addys.Addys,
 ):
+    assert _coreRipeGovVaultId != 0 # dev: invalid vault id
+
     # if no auto stake, just mint to user
     if not _shouldStake and _config.autoStakeRatio == 0:
         extcall RipeToken(_a.ripeToken).mint(_user, _amount)
@@ -1157,7 +1187,7 @@ def _handleRipeMint(
     # stake ripe tokens
     if amountToStake != 0:
         assert extcall IERC20(_a.ripeToken).approve(_a.teller, amountToStake, default_return_value=True) # dev: ripe approval failed
-        extcall Teller(_a.teller).depositFromTrusted(_user, RIPE_GOV_VAULT_ID, _a.ripeToken, amountToStake, _config.rewardsLockDuration, _a)
+        extcall Teller(_a.teller).depositFromTrusted(_user, _coreRipeGovVaultId, _a.ripeToken, amountToStake, _config.rewardsLockDuration, _a)
         assert extcall IERC20(_a.ripeToken).approve(_a.teller, 0, default_return_value=True) # dev: ripe approval failed
 
     # transfer ripe to user

--- a/contracts/core/Teller.vy
+++ b/contracts/core/Teller.vy
@@ -62,6 +62,8 @@ interface MissionControl:
     def getTellerWithdrawConfig(_asset: address, _user: address, _caller: address) -> TellerWithdrawConfig: view
     def setUserDelegation(_user: address, _delegate: address, _config: cs.ActionDelegation): nonpayable
     def setUserConfig(_user: address, _config: cs.UserConfig): nonpayable
+    def preferredStabVaultId() -> uint256: view
+    def coreRipeGovVaultId() -> uint256: view
     def shouldCheckLastTouch() -> bool: view
 
 interface CreditEngine:
@@ -212,8 +214,6 @@ MAX_STAB_REDEMPTIONS: constant(uint256) = 15
 MAX_DELEVERAGE_USERS: constant(uint256) = 25
 MAX_DELEVERAGE_ASSETS: constant(uint256) = 25
 
-STABILITY_POOL_ID: constant(uint256) = 1
-RIPE_GOV_VAULT_ID: constant(uint256) = 2
 CURVE_PRICES_ID: constant(uint256) = 2
 
 
@@ -221,6 +221,27 @@ CURVE_PRICES_ID: constant(uint256) = 2
 def __init__(_ripeHq: address, _shouldPause: bool):
     addys.__init__(_ripeHq)
     deptBasics.__init__(_shouldPause, False, False) # no minting
+
+
+#####################
+# Vault ID Pointers #
+#####################
+
+
+@view
+@internal
+def _getCoreRipeGovVaultId(_missionControl: address) -> uint256:
+    vaultId: uint256 = staticcall MissionControl(_missionControl).coreRipeGovVaultId()
+    assert vaultId != 0 # dev: invalid vault id
+    return vaultId
+
+
+@view
+@internal
+def _getPreferredStabVaultId(_missionControl: address) -> uint256:
+    vaultId: uint256 = staticcall MissionControl(_missionControl).preferredStabVaultId()
+    assert vaultId != 0 # dev: invalid vault id
+    return vaultId
 
 
 ############
@@ -654,7 +675,8 @@ def convertToSavingsGreenAndDepositIntoStabPool(_user: address = msg.sender, _gr
     sGreenAmount: uint256 = extcall IERC4626(a.savingsGreen).deposit(greenAmount, self)
     assert extcall IERC20(a.greenToken).approve(a.savingsGreen, 0, default_return_value=True) # dev: green approval failed
 
-    return self._deposit(a.savingsGreen, sGreenAmount, _user, empty(address), STABILITY_POOL_ID, msg.sender, 0, False, True, True, a)
+    vaultId: uint256 = self._getPreferredStabVaultId(a.missionControl)
+    return self._deposit(a.savingsGreen, sGreenAmount, _user, empty(address), vaultId, msg.sender, 0, False, True, True, a)
 
 
 # claims
@@ -784,7 +806,8 @@ def depositIntoGovVault(
     a: addys.Addys = addys._getAddys()
     if _user != msg.sender:
         assert staticcall TellerUtils(addys._getTellerUtilsAddr()).isUnderscoreOwnerOrLego(_user, msg.sender, a.missionControl) # dev: no perms
-    return self._deposit(_asset, _amount, _user, empty(address), RIPE_GOV_VAULT_ID, msg.sender, _lockDuration, True, False, True, a)
+    vaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+    return self._deposit(_asset, _amount, _user, empty(address), vaultId, msg.sender, _lockDuration, True, False, True, a)
 
 
 @nonreentrant
@@ -798,7 +821,8 @@ def adjustLock(_asset: address, _newLockDuration: uint256, _user: address = msg.
     if _user != msg.sender and not isSwitchboard:
         assert staticcall TellerUtils(addys._getTellerUtilsAddr()).isUnderscoreOwnerOrLego(_user, msg.sender, a.missionControl) # dev: no perms
 
-    vaultAddr: address = staticcall AddressRegistry(a.vaultBook).getAddr(RIPE_GOV_VAULT_ID)
+    vaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+    vaultAddr: address = staticcall AddressRegistry(a.vaultBook).getAddr(vaultId)
     extcall RipeGovVault(vaultAddr).adjustLock(_user, _asset, _newLockDuration, a)
     self._performHousekeeping(False, _user, True, a)
 
@@ -814,7 +838,8 @@ def releaseLock(_asset: address, _user: address = msg.sender):
     if _user != msg.sender and not isSwitchboard:
         assert staticcall TellerUtils(addys._getTellerUtilsAddr()).isUnderscoreOwnerOrLego(_user, msg.sender, a.missionControl) # dev: no perms
 
-    vaultAddr: address = staticcall AddressRegistry(a.vaultBook).getAddr(RIPE_GOV_VAULT_ID)
+    vaultId: uint256 = self._getCoreRipeGovVaultId(a.missionControl)
+    vaultAddr: address = staticcall AddressRegistry(a.vaultBook).getAddr(vaultId)
     extcall RipeGovVault(vaultAddr).releaseLock(_user, _asset, a)
     self._performHousekeeping(False, _user, True, a)
 

--- a/contracts/data/MissionControl.vy
+++ b/contracts/data/MissionControl.vy
@@ -193,6 +193,8 @@ rewardsConfig: public(cs.RipeRewardsConfig)
 totalPointsAllocs: public(TotalPointsAllocs)
 
 # vault cs
+coreRipeGovVaultId: public(uint256)
+preferredStabVaultId: public(uint256)
 ripeGovVaultConfig: public(HashMap[address, cs.RipeGovVaultConfig]) # asset -> cs
 priorityLiqAssetVaults: public(DynArray[cs.VaultLite, PRIORITY_VAULT_DATA])
 priorityStabVaults: public(DynArray[cs.VaultLite, PRIORITY_VAULT_DATA])
@@ -389,6 +391,26 @@ def _updatePointsAllocs(_asset: address, _newStakersPointsAlloc: uint256, _newVo
 ################
 # Vault Config #
 ################
+
+
+# core ripe gov vault id
+
+
+@external
+def setCoreRipeGovVaultId(_vaultId: uint256):
+    assert addys._isSwitchboardAddr(msg.sender) # dev: no perms
+    assert _vaultId != 0 # dev: invalid vault id
+    self.coreRipeGovVaultId = _vaultId
+
+
+# preferred stability pool vault id
+
+
+@external
+def setPreferredStabVaultId(_vaultId: uint256):
+    assert addys._isSwitchboardAddr(msg.sender) # dev: no perms
+    assert _vaultId != 0 # dev: invalid vault id
+    self.preferredStabVaultId = _vaultId
 
 
 # ripe gov vault

--- a/contracts/vaults/modules/StabVault.vy
+++ b/contracts/vaults/modules/StabVault.vy
@@ -18,6 +18,7 @@ interface MissionControl:
     def getTellerDepositConfig(_vaultId: uint256, _asset: address, _user: address) -> TellerDepositConfig: view
     def getStabPoolRedemptionsConfig(_asset: address, _recipient: address) -> StabPoolRedemptionsConfig: view
     def getFirstVaultIdForAsset(_asset: address) -> uint256: view
+    def coreRipeGovVaultId() -> uint256: view
 
 interface Teller:
     def depositFromTrusted(_user: address, _vaultId: uint256, _asset: address, _amount: uint256, _lockDuration: uint256, _a: addys.Addys = empty(addys.Addys)) -> uint256: nonpayable
@@ -29,6 +30,7 @@ interface PriceDesk:
 
 interface VaultBook:
     def mintRipeForStabPoolClaims(_amount: uint256, _ripeToken: address, _ledger: address) -> bool: nonpayable
+    def getRegId(_vaultAddr: address) -> uint256: view
 
 interface GreenToken:
     def burn(_amount: uint256) -> bool: nonpayable
@@ -114,7 +116,6 @@ MAX_ACTIVE_CLAIM_ASSETS: constant(uint256) = 20
 MAX_CLAIM_ASSET_MAINTENANCE: constant(uint256) = 15
 DECIMAL_OFFSET: constant(uint256) = 10 ** 8
 EIGHTEEN_DECIMALS: constant(uint256) = 10 ** 18
-RIPE_GOV_VAULT_ID: constant(uint256) = 2
 ACTIVATION_USD_THRESHOLD: constant(uint256) = 25 * 10 ** 16  # $0.25 in 18-decimal USD
 RETENTION_USD_THRESHOLD: constant(uint256) = 10 ** 17  # $0.10 in 18-decimal USD
 
@@ -786,12 +787,15 @@ def _handleClaimRewards(
     if ripeAvailable == 0:
         return
 
+    coreRipeGovVaultId: uint256 = staticcall MissionControl(_a.missionControl).coreRipeGovVaultId()
+    assert coreRipeGovVaultId != 0 # dev: invalid vault id
+
     # mint ripe
     assert extcall VaultBook(_a.vaultBook).mintRipeForStabPoolClaims(ripeAvailable, _a.ripeToken, _a.ledger) # dev: mint failed
 
     # deposit into gov vault
     assert extcall IERC20(_a.ripeToken).approve(_a.teller, ripeAvailable, default_return_value=True) # dev: ripe approval failed
-    extcall Teller(_a.teller).depositFromTrusted(_claimer, RIPE_GOV_VAULT_ID, _a.ripeToken, ripeAvailable, _lockDuration, _a)
+    extcall Teller(_a.teller).depositFromTrusted(_claimer, coreRipeGovVaultId, _a.ripeToken, ripeAvailable, _lockDuration, _a)
     assert extcall IERC20(_a.ripeToken).approve(_a.teller, 0, default_return_value=True) # dev: ripe approval failed
 
 
@@ -1027,7 +1031,7 @@ def _handleAssetForUser(
     vaultId: uint256 = staticcall MissionControl(_a.missionControl).getFirstVaultIdForAsset(_asset)
 
     # auto-deposit
-    if _shouldAutoDeposit and self._canPerformAutoDeposit(vaultId, _asset, _recipient, _a.missionControl):
+    if _shouldAutoDeposit and self._canPerformAutoDeposit(vaultId, _asset, _recipient, _a.missionControl, _a.vaultBook):
         assert extcall IERC20(_asset).approve(_a.teller, _amount, default_return_value=True) # dev: token approval failed
         extcall Teller(_a.teller).depositFromTrusted(_recipient, vaultId, _asset, _amount, 0, _a)
         assert extcall IERC20(_asset).approve(_a.teller, 0, default_return_value=True) # dev: token approval failed
@@ -1042,9 +1046,13 @@ def _canPerformAutoDeposit(
     _asset: address,
     _recipient: address,
     _missionControl: address,
+    _vaultBook: address,
 ) -> bool:
     # invalid vault or stability pool (can't deposit right back into it)
-    if _vaultId in [0, 1]:
+    if _vaultId == 0:
+        return False
+    selfVaultId: uint256 = staticcall VaultBook(_vaultBook).getRegId(self)
+    if _vaultId == selfVaultId:
         return False
     config: TellerDepositConfig = staticcall MissionControl(_missionControl).getTellerDepositConfig(_vaultId, _asset, _recipient)
     return config.canDepositGeneral and config.canDepositAsset

--- a/tests/conf_core.py
+++ b/tests/conf_core.py
@@ -40,6 +40,7 @@ def ripe_hq(
     human_resources,
     mission_control,
     switchboard,
+    switchboard_charlie,
     credit_engine,
     deleverage,
     endaoment,
@@ -182,6 +183,10 @@ def ripe_hq(
     # finish ripe hq setup
     assert ripe_hq_deploy.setRegistryTimeLockAfterSetup(sender=deploy3r)
     assert ripe_hq_deploy.finishRipeHqSetup(governance, sender=deploy3r)
+
+    # Canonical vault pointers used by the default local test deployment.
+    mission_control.setCoreRipeGovVaultId(2, sender=switchboard_charlie.address)
+    mission_control.setPreferredStabVaultId(1, sender=switchboard_charlie.address)
 
     return ripe_hq_deploy
 
@@ -726,6 +731,15 @@ def stability_pool(ripe_hq_deploy):
     )
 
 
+@pytest.fixture(scope="function")
+def alternate_stability_pool(ripe_hq):
+    return boa.load(
+        "contracts/vaults/StabilityPool.vy",
+        ripe_hq,
+        name="alternate_stability_pool",
+    )
+
+
 # ripe gov vault
 
 
@@ -735,6 +749,15 @@ def ripe_gov_vault(ripe_hq_deploy):
         "contracts/vaults/RipeGov.vy",
         ripe_hq_deploy,
         name="ripe_gov_vault",
+    )
+
+
+@pytest.fixture(scope="function")
+def alternate_ripe_gov_vault(ripe_hq):
+    return boa.load(
+        "contracts/vaults/RipeGov.vy",
+        ripe_hq,
+        name="alternate_ripe_gov_vault",
     )
 
 

--- a/tests/conf_utils.py
+++ b/tests/conf_utils.py
@@ -1,5 +1,20 @@
 import pytest
+import boa
 from constants import HUNDRED_PERCENT, MAX_UINT256, ZERO_ADDRESS, EIGHTEEN_DECIMALS
+
+
+@pytest.fixture
+def registerVault(vault_book, governance):
+    def registerVault(vault, description):
+        assert vault_book.startAddNewAddressToRegistry(
+            vault.address,
+            description,
+            sender=governance.address,
+        )
+        boa.env.time_travel(blocks=vault_book.registryChangeTimeLock())
+        return vault_book.confirmNewAddressToRegistry(vault.address, sender=governance.address)
+
+    yield registerVault
 
 
 def filter_logs(contract, event_name, _strict=False):

--- a/tests/config/test_switchboard_alpha.py
+++ b/tests/config/test_switchboard_alpha.py
@@ -5,6 +5,32 @@ from constants import MAX_UINT256, ZERO_ADDRESS
 from conf_utils import filter_logs
 
 
+def _asset_config(vault_ids):
+    return (
+        vault_ids,
+        0,
+        0,
+        MAX_UINT256,
+        MAX_UINT256,
+        0,
+        (0, 0, 0, 0, 0, 0),
+        False,
+        False,
+        False,
+        True,
+        True,
+        True,
+        False,
+        True,
+        True,
+        True,
+        0,
+        (False, 0, 0, 0, 0),
+        ZERO_ADDRESS,
+        False,
+    )
+
+
 @pytest.fixture(scope="function")
 def new_mission_control(ripe_hq, defaults):
     """Deploy a new MissionControl that is NOT registered in RipeHq.
@@ -1973,7 +1999,8 @@ def test_ripe_gov_vault_config_validation(switchboard_alpha, governance, alpha_t
             True,    # can exit
             sender=governance.address
         )
-    
+
+
     # Test with unsupported asset (not configured in vault 2)
     with boa.reverts("invalid ripe vault config"):
         switchboard_alpha.setRipeGovVaultConfig(
@@ -2071,6 +2098,105 @@ def test_ripe_gov_vault_config_validation(switchboard_alpha, governance, alpha_t
             False,  # canExit = False
             sender=governance.address
         )
+
+
+def test_ripe_gov_vault_config_rejects_unset_target_core_pointer(
+    switchboard_alpha,
+    switchboard_bravo,
+    governance,
+    new_mission_control,
+    alpha_token,
+):
+    new_mission_control.setAssetConfig(
+        alpha_token.address,
+        _asset_config([2]),
+        sender=switchboard_bravo.address,
+    )
+
+    with boa.reverts("invalid ripe vault config"):
+        switchboard_alpha.setRipeGovVaultConfig(
+            alpha_token.address,
+            100_00,
+            False,
+            100,
+            1_000,
+            200_00,
+            0,
+            False,
+            new_mission_control.address,
+            sender=governance.address,
+        )
+
+
+def test_ripe_gov_vault_config_uses_target_mission_control_pointer(
+    switchboard_alpha,
+    switchboard_bravo,
+    governance,
+    mission_control,
+    new_mission_control,
+    alpha_token,
+):
+    target_core_id = 77
+    new_mission_control.setCoreRipeGovVaultId(target_core_id, sender=switchboard_alpha.address)
+    new_mission_control.setAssetConfig(
+        alpha_token.address,
+        _asset_config([target_core_id]),
+        sender=switchboard_bravo.address,
+    )
+    assert not mission_control.isSupportedAsset(alpha_token.address)
+
+    action_id = switchboard_alpha.setRipeGovVaultConfig(
+        alpha_token.address,
+        100_00,
+        False,
+        100,
+        1_000,
+        200_00,
+        0,
+        False,
+        new_mission_control.address,
+        sender=governance.address,
+    )
+    assert switchboard_alpha.pendingMissionControl(action_id) == new_mission_control.address
+
+    boa.env.time_travel(blocks=switchboard_alpha.actionTimeLock())
+    assert switchboard_alpha.executePendingAction(action_id, sender=governance.address)
+    assert new_mission_control.ripeGovVaultConfig(alpha_token.address).assetWeight == 100_00
+    assert mission_control.ripeGovVaultConfig(alpha_token.address).assetWeight == 0
+
+
+def test_ripe_gov_vault_config_execution_keeps_existing_no_revalidation_behavior(
+    switchboard_alpha,
+    switchboard_bravo,
+    governance,
+    new_mission_control,
+    alpha_token,
+):
+    target_core_id = 77
+    new_mission_control.setCoreRipeGovVaultId(target_core_id, sender=switchboard_alpha.address)
+    new_mission_control.setAssetConfig(
+        alpha_token.address,
+        _asset_config([target_core_id]),
+        sender=switchboard_bravo.address,
+    )
+    action_id = switchboard_alpha.setRipeGovVaultConfig(
+        alpha_token.address,
+        100_00,
+        False,
+        100,
+        1_000,
+        200_00,
+        0,
+        False,
+        new_mission_control.address,
+        sender=governance.address,
+    )
+
+    new_mission_control.setCoreRipeGovVaultId(88, sender=switchboard_alpha.address)
+    boa.env.time_travel(blocks=switchboard_alpha.actionTimeLock())
+
+    assert switchboard_alpha.executePendingAction(action_id, sender=governance.address)
+    assert new_mission_control.ripeGovVaultConfig(alpha_token.address).assetWeight == 100_00
 
 
 def test_ripe_gov_vault_config_success(switchboard_alpha, governance, alpha_token, setAssetConfig):

--- a/tests/config/test_switchboard_bravo.py
+++ b/tests/config/test_switchboard_bravo.py
@@ -5,23 +5,72 @@ from constants import MAX_UINT256, ZERO_ADDRESS
 from conf_utils import filter_logs
 
 
+def _add_asset(
+    switchboard_bravo,
+    governance,
+    asset,
+    vault_ids,
+    stakers_points_alloc,
+    mission_control=ZERO_ADDRESS,
+):
+    return switchboard_bravo.addAsset(
+        asset,
+        vault_ids,
+        stakers_points_alloc,
+        0,
+        1_000,
+        10_000,
+        0,
+        (0, 0, 0, 0, 0, 0),
+        False,
+        False,
+        False,
+        True,
+        True,
+        True,
+        False,
+        True,
+        True,
+        True,
+        0,
+        (False, 0, 0, 0, 0),
+        ZERO_ADDRESS,
+        False,
+        mission_control,
+        sender=governance.address,
+    )
+
+
 ###############
 # Test Fixtures
 ###############
 
 
 @pytest.fixture(scope="function")
-def new_mission_control(ripe_hq, defaults):
+def new_mission_control(ripe_hq, defaults, switchboard_bravo):
     """Deploy a new MissionControl that is NOT registered in RipeHq.
 
     Uses the same RipeHq so SwitchboardBravo/Charlie are authorized as switchboards,
     but this MC itself is not registered in the HQ registry.
     """
-    return boa.load(
+    mc = boa.load(
         "contracts/data/MissionControl.vy",
         ripe_hq,
         defaults,
         name="new_mission_control",
+    )
+    mc.setCoreRipeGovVaultId(2, sender=switchboard_bravo.address)
+    mc.setPreferredStabVaultId(1, sender=switchboard_bravo.address)
+    return mc
+
+
+@pytest.fixture(scope="function")
+def zero_pointer_mission_control(ripe_hq, defaults):
+    return boa.load(
+        "contracts/data/MissionControl.vy",
+        ripe_hq,
+        defaults,
+        name="zero_pointer_mission_control",
     )
 
 
@@ -32,6 +81,167 @@ def new_mission_control(ripe_hq, defaults):
 
 def test_deployment_success(switchboard_bravo):
     assert switchboard_bravo.actionId() == 1  # starts at 1
+
+
+@pytest.mark.parametrize("matching_vault_id", [3, 4])
+def test_staker_allocation_accepts_either_configured_pointer(
+    switchboard_bravo,
+    governance,
+    new_mission_control,
+    alpha_token,
+    matching_vault_id,
+):
+    new_mission_control.setCoreRipeGovVaultId(3, sender=switchboard_bravo.address)
+    new_mission_control.setPreferredStabVaultId(4, sender=switchboard_bravo.address)
+
+    action_id = _add_asset(
+        switchboard_bravo,
+        governance,
+        alpha_token.address,
+        [matching_vault_id],
+        50_00,
+        new_mission_control.address,
+    )
+    assert action_id > 0
+
+
+def test_staker_allocation_rejects_when_neither_configured_pointer_is_present(
+    switchboard_bravo,
+    governance,
+    new_mission_control,
+    alpha_token,
+):
+    new_mission_control.setCoreRipeGovVaultId(3, sender=switchboard_bravo.address)
+    new_mission_control.setPreferredStabVaultId(4, sender=switchboard_bravo.address)
+
+    with boa.reverts("invalid asset"):
+        _add_asset(
+            switchboard_bravo,
+            governance,
+            alpha_token.address,
+            [1, 2],
+            50_00,
+            new_mission_control.address,
+        )
+
+
+def test_staker_allocation_rejects_unset_pointers_but_zero_allocation_remains_valid(
+    switchboard_bravo,
+    governance,
+    zero_pointer_mission_control,
+    alpha_token,
+):
+    with boa.reverts("invalid asset"):
+        _add_asset(
+            switchboard_bravo,
+            governance,
+            alpha_token.address,
+            [1],
+            50_00,
+            zero_pointer_mission_control.address,
+        )
+
+    action_id = _add_asset(
+        switchboard_bravo,
+        governance,
+        alpha_token.address,
+        [1],
+        0,
+        zero_pointer_mission_control.address,
+    )
+    assert action_id > 0
+
+
+@pytest.mark.parametrize(
+    ("setter_name", "configured_vault_id"),
+    [
+        ("setCoreRipeGovVaultId", 3),
+        ("setPreferredStabVaultId", 4),
+    ],
+)
+def test_staker_allocation_accepts_one_configured_pointer_when_the_other_is_unset(
+    switchboard_bravo,
+    governance,
+    zero_pointer_mission_control,
+    alpha_token,
+    setter_name,
+    configured_vault_id,
+):
+    getattr(zero_pointer_mission_control, setter_name)(
+        configured_vault_id,
+        sender=switchboard_bravo.address,
+    )
+    action_id = _add_asset(
+        switchboard_bravo,
+        governance,
+        alpha_token.address,
+        [configured_vault_id],
+        50_00,
+        zero_pointer_mission_control.address,
+    )
+    assert action_id > 0
+
+
+def test_staker_pointer_validation_is_repeated_at_execution(
+    switchboard_bravo,
+    governance,
+    new_mission_control,
+    alpha_token,
+):
+    new_mission_control.setCoreRipeGovVaultId(3, sender=switchboard_bravo.address)
+    new_mission_control.setPreferredStabVaultId(4, sender=switchboard_bravo.address)
+    action_id = _add_asset(
+        switchboard_bravo,
+        governance,
+        alpha_token.address,
+        [3],
+        50_00,
+        new_mission_control.address,
+    )
+
+    new_mission_control.setCoreRipeGovVaultId(4, sender=switchboard_bravo.address)
+    boa.env.time_travel(blocks=switchboard_bravo.actionTimeLock())
+
+    with boa.reverts("invalid asset config"):
+        switchboard_bravo.executePendingAction(action_id, sender=governance.address)
+
+
+def test_asset_deposit_param_update_uses_target_mission_control_pointers(
+    switchboard_bravo,
+    governance,
+    new_mission_control,
+    alpha_token,
+):
+    new_mission_control.setCoreRipeGovVaultId(3, sender=switchboard_bravo.address)
+    new_mission_control.setPreferredStabVaultId(4, sender=switchboard_bravo.address)
+    add_action = _add_asset(
+        switchboard_bravo,
+        governance,
+        alpha_token.address,
+        [3],
+        50_00,
+        new_mission_control.address,
+    )
+    boa.env.time_travel(blocks=switchboard_bravo.actionTimeLock())
+    assert switchboard_bravo.executePendingAction(add_action, sender=governance.address)
+
+    update_action = switchboard_bravo.setAssetDepositParams(
+        alpha_token.address,
+        [4],
+        25_00,
+        0,
+        2_000,
+        20_000,
+        0,
+        new_mission_control.address,
+        sender=governance.address,
+    )
+    boa.env.time_travel(blocks=switchboard_bravo.actionTimeLock())
+    assert switchboard_bravo.executePendingAction(update_action, sender=governance.address)
+
+    config = new_mission_control.assetConfig(alpha_token.address)
+    assert list(config.vaultIds) == [4]
+    assert config.stakersPointsAlloc == 25_00
 
 
 def test_governance_permissions(switchboard_bravo, bob):

--- a/tests/config/test_switchboard_charlie.py
+++ b/tests/config/test_switchboard_charlie.py
@@ -1,8 +1,52 @@
 import pytest
 import boa
 
-from constants import ZERO_ADDRESS
+from constants import MAX_UINT256, ZERO_ADDRESS
 from conf_utils import filter_logs
+
+
+def _asset_config(vault_ids):
+    return (
+        vault_ids,
+        0,
+        0,
+        MAX_UINT256,
+        MAX_UINT256,
+        0,
+        (0, 0, 0, 0, 0, 0),
+        False,
+        False,
+        False,
+        True,
+        True,
+        True,
+        False,
+        True,
+        True,
+        True,
+        0,
+        (False, 0, 0, 0, 0),
+        ZERO_ADDRESS,
+        False,
+    )
+
+
+def _support_asset(mission_control, switchboard_bravo, asset, vault_ids):
+    mission_control.setAssetConfig(
+        asset,
+        _asset_config(vault_ids),
+        sender=switchboard_bravo.address,
+    )
+
+
+def _register_vault(vault_book, governance, vault, description):
+    assert vault_book.startAddNewAddressToRegistry(
+        vault.address,
+        description,
+        sender=governance.address,
+    )
+    boa.env.time_travel(blocks=vault_book.registryChangeTimeLock())
+    return vault_book.confirmNewAddressToRegistry(vault.address, sender=governance.address)
 
 
 ###############
@@ -17,17 +61,31 @@ def mock_auction_house():
 
 
 @pytest.fixture(scope="function")
-def new_mission_control(ripe_hq, defaults):
+def new_mission_control(ripe_hq, defaults, switchboard_charlie):
     """Deploy a new MissionControl that is NOT registered in RipeHq.
 
     Uses the same RipeHq so SwitchboardBravo/Charlie are authorized as switchboards,
     but this MC itself is not registered in the HQ registry.
     """
-    return boa.load(
+    mission_control = boa.load(
         "contracts/data/MissionControl.vy",
         ripe_hq,
         defaults,
         name="new_mission_control",
+    )
+    mission_control.setCoreRipeGovVaultId(2, sender=switchboard_charlie.address)
+    mission_control.setPreferredStabVaultId(1, sender=switchboard_charlie.address)
+    return mission_control
+
+
+@pytest.fixture(scope="function")
+def zero_pointer_mission_control(ripe_hq, defaults):
+    """Deploy an unregistered MissionControl with both pointers intentionally unset."""
+    return boa.load(
+        "contracts/data/MissionControl.vy",
+        ripe_hq,
+        defaults,
+        name="zero_pointer_mission_control",
     )
 
 
@@ -2910,6 +2968,333 @@ def test_deregister_vault_asset_cancellation(
 
     # Verify action was cancelled
     assert switchboard_charlie.actionType(aid) == 0
+
+
+################################
+# Canonical Vault ID Pointers  #
+################################
+
+
+def test_vault_pointer_actions_require_governance_and_reject_basic_invalid_ids(
+    switchboard_charlie,
+    governance,
+    alice,
+):
+    with boa.reverts("no perms"):
+        switchboard_charlie.setCoreRipeGovVaultId(2, sender=alice)
+    with boa.reverts("no perms"):
+        switchboard_charlie.setPreferredStabVaultId(1, sender=alice)
+
+    with boa.reverts("invalid vault id"):
+        switchboard_charlie.setCoreRipeGovVaultId(0, sender=governance.address)
+    with boa.reverts("invalid vault id"):
+        switchboard_charlie.setPreferredStabVaultId(0, sender=governance.address)
+    with boa.reverts("invalid vault id"):
+        switchboard_charlie.setCoreRipeGovVaultId(999, sender=governance.address)
+    with boa.reverts("invalid vault id"):
+        switchboard_charlie.setPreferredStabVaultId(999, sender=governance.address)
+
+    with boa.reverts("already set"):
+        switchboard_charlie.setCoreRipeGovVaultId(2, sender=governance.address)
+    with boa.reverts("already set"):
+        switchboard_charlie.setPreferredStabVaultId(1, sender=governance.address)
+
+
+def test_vault_pointer_actions_reject_contracts_with_wrong_interfaces(
+    switchboard_charlie,
+    switchboard_bravo,
+    governance,
+    vault_book,
+    mission_control,
+    mock_rando_contract,
+    ripe_token,
+    savings_green,
+):
+    vault_id = _register_vault(vault_book, governance, mock_rando_contract, "Wrong Interface")
+    _support_asset(mission_control, switchboard_bravo, ripe_token.address, [vault_id])
+    _support_asset(mission_control, switchboard_bravo, savings_green.address, [vault_id])
+
+    with boa.reverts():
+        switchboard_charlie.setCoreRipeGovVaultId(vault_id, sender=governance.address)
+    with boa.reverts():
+        switchboard_charlie.setPreferredStabVaultId(vault_id, sender=governance.address)
+
+
+def test_vault_pointer_actions_reject_malformed_probe_return_data(
+    switchboard_charlie,
+    switchboard_bravo,
+    governance,
+    vault_book,
+    mission_control,
+    ripe_token,
+    savings_green,
+):
+    malformed_vault = boa.loads(
+        """
+@external
+def totalGovPoints():
+    pass
+
+@external
+def totalClaimableBalances(_asset: address):
+    pass
+
+@external
+@view
+def isPaused() -> bool:
+    return False
+""",
+        name="malformed_pointer_vault",
+    )
+    vault_id = _register_vault(vault_book, governance, malformed_vault, "Malformed Probe Returns")
+    _support_asset(mission_control, switchboard_bravo, ripe_token.address, [vault_id])
+    _support_asset(mission_control, switchboard_bravo, savings_green.address, [vault_id])
+
+    with boa.reverts():
+        switchboard_charlie.setCoreRipeGovVaultId(vault_id, sender=governance.address)
+    with boa.reverts():
+        switchboard_charlie.setPreferredStabVaultId(vault_id, sender=governance.address)
+
+
+def test_vault_pointer_actions_reject_unsupported_and_paused_candidates(
+    switchboard_charlie,
+    switchboard_bravo,
+    governance,
+    vault_book,
+    mission_control,
+    alternate_ripe_gov_vault,
+    alternate_stability_pool,
+    ripe_token,
+    savings_green,
+):
+    core_id = _register_vault(vault_book, governance, alternate_ripe_gov_vault, "Alternate RipeGov")
+    preferred_id = _register_vault(vault_book, governance, alternate_stability_pool, "Alternate Stability Pool")
+
+    with boa.reverts("unsupported asset"):
+        switchboard_charlie.setCoreRipeGovVaultId(core_id, sender=governance.address)
+    with boa.reverts("unsupported asset"):
+        switchboard_charlie.setPreferredStabVaultId(preferred_id, sender=governance.address)
+
+    _support_asset(mission_control, switchboard_bravo, ripe_token.address, [core_id])
+    _support_asset(mission_control, switchboard_bravo, savings_green.address, [preferred_id])
+    switchboard_charlie.pause(alternate_ripe_gov_vault.address, True, sender=governance.address)
+    switchboard_charlie.pause(alternate_stability_pool.address, True, sender=governance.address)
+
+    with boa.reverts("vault paused"):
+        switchboard_charlie.setCoreRipeGovVaultId(core_id, sender=governance.address)
+    with boa.reverts("vault paused"):
+        switchboard_charlie.setPreferredStabVaultId(preferred_id, sender=governance.address)
+
+
+def test_vault_pointer_actions_allow_explicit_initialization_from_zero(
+    switchboard_charlie,
+    switchboard_bravo,
+    governance,
+    zero_pointer_mission_control,
+    ripe_token,
+    savings_green,
+):
+    _support_asset(zero_pointer_mission_control, switchboard_bravo, ripe_token.address, [2])
+    _support_asset(zero_pointer_mission_control, switchboard_bravo, savings_green.address, [1])
+
+    core_action = switchboard_charlie.setCoreRipeGovVaultId(
+        2,
+        zero_pointer_mission_control.address,
+        sender=governance.address,
+    )
+    core_pending = filter_logs(switchboard_charlie, "PendingCoreRipeGovVaultIdChange")[0]
+    assert core_pending.previousVaultId == 0
+    assert core_pending.newVaultId == 2
+    assert core_pending.actionId == core_action
+
+    preferred_action = switchboard_charlie.setPreferredStabVaultId(
+        1,
+        zero_pointer_mission_control.address,
+        sender=governance.address,
+    )
+    preferred_pending = filter_logs(switchboard_charlie, "PendingPreferredStabVaultIdChange")[0]
+    assert preferred_pending.previousVaultId == 0
+    assert preferred_pending.newVaultId == 1
+    assert preferred_pending.actionId == preferred_action
+
+    boa.env.time_travel(blocks=switchboard_charlie.actionTimeLock())
+    assert switchboard_charlie.executePendingAction(core_action, sender=governance.address)
+    assert switchboard_charlie.executePendingAction(preferred_action, sender=governance.address)
+    assert zero_pointer_mission_control.coreRipeGovVaultId() == 2
+    assert zero_pointer_mission_control.preferredStabVaultId() == 1
+
+
+def test_core_pointer_action_lifecycle_and_candidate_mission_control(
+    switchboard_charlie,
+    switchboard_bravo,
+    governance,
+    vault_book,
+    mission_control,
+    zero_pointer_mission_control,
+    alternate_ripe_gov_vault,
+    ripe_token,
+):
+    vault_id = _register_vault(vault_book, governance, alternate_ripe_gov_vault, "Alternate RipeGov")
+    _support_asset(zero_pointer_mission_control, switchboard_bravo, ripe_token.address, [vault_id])
+    assert zero_pointer_mission_control.coreRipeGovVaultId() == 0
+
+    action_id = switchboard_charlie.setCoreRipeGovVaultId(
+        vault_id,
+        zero_pointer_mission_control.address,
+        sender=governance.address,
+    )
+    pending_log = filter_logs(switchboard_charlie, "PendingCoreRipeGovVaultIdChange")[0]
+    assert pending_log.previousVaultId == 0
+    assert pending_log.newVaultId == vault_id
+    assert pending_log.newVaultAddr == alternate_ripe_gov_vault.address
+    assert pending_log.confirmationBlock == switchboard_charlie.getActionConfirmationBlock(action_id)
+    assert pending_log.actionId == action_id
+    assert switchboard_charlie.pendingCoreRipeGovVaultId(action_id) == vault_id
+    assert switchboard_charlie.pendingMissionControl(action_id) == zero_pointer_mission_control.address
+    assert switchboard_charlie.hasPendingAction(action_id)
+
+    assert not switchboard_charlie.executePendingAction(action_id, sender=governance.address)
+    boa.env.time_travel(blocks=switchboard_charlie.actionTimeLock())
+    assert switchboard_charlie.executePendingAction(action_id, sender=governance.address)
+
+    final_log = filter_logs(switchboard_charlie, "CoreRipeGovVaultIdSet")[0]
+    assert final_log.previousVaultId == 0
+    assert final_log.newVaultId == vault_id
+    assert final_log.newVaultAddr == alternate_ripe_gov_vault.address
+    assert zero_pointer_mission_control.coreRipeGovVaultId() == vault_id
+    assert mission_control.coreRipeGovVaultId() == 2
+    assert switchboard_charlie.actionType(action_id) == 0
+    assert not switchboard_charlie.hasPendingAction(action_id)
+
+
+def test_preferred_pointer_final_event_uses_execution_time_previous_id(
+    switchboard_charlie,
+    switchboard_alpha,
+    switchboard_bravo,
+    governance,
+    vault_book,
+    mission_control,
+    alternate_stability_pool,
+    savings_green,
+):
+    vault_id = _register_vault(vault_book, governance, alternate_stability_pool, "Alternate Stability Pool")
+    _support_asset(mission_control, switchboard_bravo, savings_green.address, [1, vault_id])
+    action_id = switchboard_charlie.setPreferredStabVaultId(vault_id, sender=governance.address)
+
+    mission_control.setPreferredStabVaultId(999, sender=switchboard_alpha.address)
+    boa.env.time_travel(blocks=switchboard_charlie.actionTimeLock())
+    assert switchboard_charlie.executePendingAction(action_id, sender=governance.address)
+
+    final_log = filter_logs(switchboard_charlie, "PreferredStabVaultIdSet")[0]
+    assert final_log.previousVaultId == 999
+    assert final_log.newVaultId == vault_id
+    assert final_log.newVaultAddr == alternate_stability_pool.address
+    assert mission_control.preferredStabVaultId() == vault_id
+
+
+def test_pointer_execution_revalidates_noop_pause_and_asset_support_changes(
+    switchboard_charlie,
+    switchboard_alpha,
+    switchboard_bravo,
+    governance,
+    vault_book,
+    mission_control,
+    alternate_ripe_gov_vault,
+    alternate_stability_pool,
+    ripe_token,
+    savings_green,
+):
+    core_id = _register_vault(vault_book, governance, alternate_ripe_gov_vault, "Alternate RipeGov")
+    preferred_id = _register_vault(vault_book, governance, alternate_stability_pool, "Alternate Stability Pool")
+    _support_asset(mission_control, switchboard_bravo, ripe_token.address, [2, core_id])
+    _support_asset(mission_control, switchboard_bravo, savings_green.address, [1, preferred_id])
+
+    noop_action = switchboard_charlie.setCoreRipeGovVaultId(core_id, sender=governance.address)
+    mission_control.setCoreRipeGovVaultId(core_id, sender=switchboard_alpha.address)
+    boa.env.time_travel(blocks=switchboard_charlie.actionTimeLock())
+    with boa.reverts("already set"):
+        switchboard_charlie.executePendingAction(noop_action, sender=governance.address)
+
+    mission_control.setCoreRipeGovVaultId(2, sender=switchboard_alpha.address)
+    pause_action = switchboard_charlie.setCoreRipeGovVaultId(core_id, sender=governance.address)
+    switchboard_charlie.pause(alternate_ripe_gov_vault.address, True, sender=governance.address)
+    boa.env.time_travel(blocks=switchboard_charlie.actionTimeLock())
+    with boa.reverts("vault paused"):
+        switchboard_charlie.executePendingAction(pause_action, sender=governance.address)
+    switchboard_charlie.pause(alternate_ripe_gov_vault.address, False, sender=governance.address)
+    assert switchboard_charlie.executePendingAction(pause_action, sender=governance.address)
+
+    support_action = switchboard_charlie.setPreferredStabVaultId(preferred_id, sender=governance.address)
+    _support_asset(mission_control, switchboard_bravo, savings_green.address, [1])
+    boa.env.time_travel(blocks=switchboard_charlie.actionTimeLock())
+    with boa.reverts("unsupported asset"):
+        switchboard_charlie.executePendingAction(support_action, sender=governance.address)
+    _support_asset(mission_control, switchboard_bravo, savings_green.address, [1, preferred_id])
+    assert switchboard_charlie.executePendingAction(support_action, sender=governance.address)
+
+
+def test_pointer_execution_uses_current_vault_book_binding(
+    switchboard_charlie,
+    switchboard_bravo,
+    governance,
+    vault_book,
+    mission_control,
+    alternate_ripe_gov_vault,
+    ripe_hq,
+    ripe_token,
+):
+    vault_id = _register_vault(vault_book, governance, alternate_ripe_gov_vault, "Alternate RipeGov")
+    _support_asset(mission_control, switchboard_bravo, ripe_token.address, [2, vault_id])
+    action_id = switchboard_charlie.setCoreRipeGovVaultId(vault_id, sender=governance.address)
+
+    replacement = boa.load(
+        "contracts/vaults/RipeGov.vy",
+        ripe_hq,
+        name="replacement_ripe_gov_vault",
+    )
+    assert vault_book.startAddressUpdateToRegistry(
+        vault_id,
+        replacement.address,
+        sender=governance.address,
+    )
+    boa.env.time_travel(blocks=vault_book.registryChangeTimeLock())
+    assert vault_book.confirmAddressUpdateToRegistry(vault_id, sender=governance.address)
+
+    confirmation_block = switchboard_charlie.getActionConfirmationBlock(action_id)
+    if boa.env.evm.patch.block_number < confirmation_block:
+        boa.env.time_travel(blocks=confirmation_block - boa.env.evm.patch.block_number)
+    assert switchboard_charlie.executePendingAction(action_id, sender=governance.address)
+
+    final_log = filter_logs(switchboard_charlie, "CoreRipeGovVaultIdSet")[0]
+    assert final_log.newVaultAddr == replacement.address
+    assert vault_book.getAddr(vault_id) == replacement.address
+
+
+def test_pointer_actions_follow_normal_cancellation_and_expiration_paths(
+    switchboard_charlie,
+    switchboard_bravo,
+    governance,
+    vault_book,
+    mission_control,
+    alternate_stability_pool,
+    savings_green,
+):
+    vault_id = _register_vault(vault_book, governance, alternate_stability_pool, "Alternate Stability Pool")
+    _support_asset(mission_control, switchboard_bravo, savings_green.address, [1, vault_id])
+
+    cancelled_action = switchboard_charlie.setPreferredStabVaultId(vault_id, sender=governance.address)
+    assert switchboard_charlie.cancelPendingAction(cancelled_action, sender=governance.address)
+    assert switchboard_charlie.actionType(cancelled_action) == 0
+    boa.env.time_travel(blocks=switchboard_charlie.actionTimeLock())
+    assert not switchboard_charlie.executePendingAction(cancelled_action, sender=governance.address)
+
+    expired_action = switchboard_charlie.setPreferredStabVaultId(vault_id, sender=governance.address)
+    boa.env.time_travel(
+        blocks=switchboard_charlie.actionTimeLock() + switchboard_charlie.expiration()
+    )
+    assert not switchboard_charlie.executePendingAction(expired_action, sender=governance.address)
+    assert switchboard_charlie.actionType(expired_action) == 0
+    assert mission_control.preferredStabVaultId() == 1
 
 
 # Run the tests

--- a/tests/config/test_switchboard_charlie.py
+++ b/tests/config/test_switchboard_charlie.py
@@ -3297,6 +3297,183 @@ def test_pointer_actions_follow_normal_cancellation_and_expiration_paths(
     assert mission_control.preferredStabVaultId() == 1
 
 
+@pytest.mark.parametrize("pointer_kind", ["core", "preferred"])
+@pytest.mark.parametrize("replacement_kind", ["wrong_interface", "malformed_probe"])
+def test_pointer_execution_rejects_invalid_rebound_contract(
+    switchboard_charlie,
+    switchboard_bravo,
+    governance,
+    vault_book,
+    mission_control,
+    alternate_ripe_gov_vault,
+    alternate_stability_pool,
+    ripe_token,
+    savings_green,
+    pointer_kind,
+    replacement_kind,
+):
+    if pointer_kind == "core":
+        candidate = alternate_ripe_gov_vault
+        asset = ripe_token
+        initial_id = 2
+        setter = switchboard_charlie.setCoreRipeGovVaultId
+        pointer_view = mission_control.coreRipeGovVaultId
+        pending_view = switchboard_charlie.pendingCoreRipeGovVaultId
+        probe_source = """
+@external
+def totalGovPoints():
+    pass
+
+@external
+@view
+def isPaused() -> bool:
+    return False
+"""
+    else:
+        candidate = alternate_stability_pool
+        asset = savings_green
+        initial_id = 1
+        setter = switchboard_charlie.setPreferredStabVaultId
+        pointer_view = mission_control.preferredStabVaultId
+        pending_view = switchboard_charlie.pendingPreferredStabVaultId
+        probe_source = """
+@external
+def totalClaimableBalances(_asset: address):
+    pass
+
+@external
+@view
+def isPaused() -> bool:
+    return False
+"""
+
+    vault_id = _register_vault(
+        vault_book,
+        governance,
+        candidate,
+        f"Rebound {pointer_kind} candidate",
+    )
+    _support_asset(
+        mission_control,
+        switchboard_bravo,
+        asset.address,
+        [initial_id, vault_id],
+    )
+    action_id = setter(vault_id, sender=governance.address)
+
+    if replacement_kind == "wrong_interface":
+        replacement = boa.loads(
+            """
+@external
+@view
+def isPaused() -> bool:
+    return False
+""",
+            name=f"rebound_{pointer_kind}_wrong_interface",
+        )
+    else:
+        replacement = boa.loads(
+            probe_source,
+            name=f"rebound_{pointer_kind}_malformed_probe",
+        )
+
+    assert vault_book.startAddressUpdateToRegistry(
+        vault_id,
+        replacement,
+        sender=governance.address,
+    )
+    boa.env.time_travel(blocks=vault_book.registryChangeTimeLock())
+    assert vault_book.confirmAddressUpdateToRegistry(
+        vault_id,
+        sender=governance.address,
+    )
+
+    confirmation_block = switchboard_charlie.getActionConfirmationBlock(action_id)
+    if boa.env.evm.patch.block_number < confirmation_block:
+        boa.env.time_travel(
+            blocks=confirmation_block - boa.env.evm.patch.block_number
+        )
+    with boa.reverts():
+        switchboard_charlie.executePendingAction(
+            action_id,
+            sender=governance.address,
+        )
+
+    assert pointer_view() == initial_id
+    assert pending_view(action_id) == vault_id
+    assert switchboard_charlie.actionType(action_id) != 0
+    assert switchboard_charlie.hasPendingAction(action_id)
+
+
+@pytest.mark.parametrize("pointer_kind", ["core", "preferred"])
+def test_pointer_execution_rejects_disabled_vault_binding(
+    switchboard_charlie,
+    switchboard_bravo,
+    governance,
+    vault_book,
+    mission_control,
+    alternate_ripe_gov_vault,
+    alternate_stability_pool,
+    ripe_token,
+    savings_green,
+    pointer_kind,
+):
+    if pointer_kind == "core":
+        candidate = alternate_ripe_gov_vault
+        asset = ripe_token
+        initial_id = 2
+        setter = switchboard_charlie.setCoreRipeGovVaultId
+        pointer_view = mission_control.coreRipeGovVaultId
+        pending_view = switchboard_charlie.pendingCoreRipeGovVaultId
+    else:
+        candidate = alternate_stability_pool
+        asset = savings_green
+        initial_id = 1
+        setter = switchboard_charlie.setPreferredStabVaultId
+        pointer_view = mission_control.preferredStabVaultId
+        pending_view = switchboard_charlie.pendingPreferredStabVaultId
+
+    vault_id = _register_vault(
+        vault_book,
+        governance,
+        candidate,
+        f"Disabled {pointer_kind} candidate",
+    )
+    _support_asset(
+        mission_control,
+        switchboard_bravo,
+        asset.address,
+        [initial_id, vault_id],
+    )
+    action_id = setter(vault_id, sender=governance.address)
+
+    assert vault_book.startAddressDisableInRegistry(
+        vault_id,
+        sender=governance.address,
+    )
+    boa.env.time_travel(blocks=vault_book.registryChangeTimeLock())
+    assert vault_book.confirmAddressDisableInRegistry(
+        vault_id,
+        sender=governance.address,
+    )
+
+    confirmation_block = switchboard_charlie.getActionConfirmationBlock(action_id)
+    if boa.env.evm.patch.block_number < confirmation_block:
+        boa.env.time_travel(
+            blocks=confirmation_block - boa.env.evm.patch.block_number
+        )
+    with boa.reverts("invalid vault"):
+        switchboard_charlie.executePendingAction(
+            action_id,
+            sender=governance.address,
+        )
+
+    assert pointer_view() == initial_id
+    assert pending_view(action_id) == vault_id
+    assert switchboard_charlie.actionType(action_id) != 0
+    assert switchboard_charlie.hasPendingAction(action_id)
+
+
 # Run the tests
 if __name__ == "__main__":
     print("Additional comprehensive tests for SwitchboardThree.vy")

--- a/tests/core/bondRoom/test_ripe_bonds.py
+++ b/tests/core/bondRoom/test_ripe_bonds.py
@@ -247,6 +247,57 @@ def test_purchase_ripe_bond_with_minimum_lock_duration(
     _test(ripe_payout, expected_deposit)
 
 
+def test_locked_bond_purchase_uses_core_governance_vault_pointer(
+    teller,
+    setupRipeBonds,
+    bob,
+    alpha_token_whale,
+    alpha_token,
+    ripe_token,
+    ripe_gov_vault,
+    alternate_ripe_gov_vault,
+    registerVault,
+    mission_control,
+    switchboard_alpha,
+    setAssetConfig,
+):
+    setupRipeBonds()
+    core_id = registerVault(alternate_ripe_gov_vault, "Core RipeGov")
+    setAssetConfig(ripe_token, _vaultIds=[core_id])
+    mission_control.setCoreRipeGovVaultId(core_id, sender=switchboard_alpha.address)
+
+    payment_amount = 100 * EIGHTEEN_DECIMALS
+    alpha_token.transfer(bob, payment_amount, sender=alpha_token_whale)
+    alpha_token.approve(teller, payment_amount, sender=bob)
+    ripe_payout = teller.purchaseRipeBond(
+        alpha_token,
+        payment_amount,
+        100,
+        sender=bob,
+    )
+
+    assert alternate_ripe_gov_vault.getTotalAmountForUser(bob, ripe_token) == ripe_payout
+    assert ripe_gov_vault.getTotalAmountForUser(bob, ripe_token) == 0
+
+
+def test_locked_bond_purchase_fails_closed_when_core_pointer_is_unset(
+    teller,
+    setupRipeBonds,
+    bob,
+    alpha_token_whale,
+    alpha_token,
+    mission_control,
+):
+    setupRipeBonds()
+    mission_control.eval("self.coreRipeGovVaultId = 0")
+
+    payment_amount = 100 * EIGHTEEN_DECIMALS
+    alpha_token.transfer(bob, payment_amount, sender=alpha_token_whale)
+    alpha_token.approve(teller, payment_amount, sender=bob)
+    with boa.reverts("invalid vault id"):
+        teller.purchaseRipeBond(alpha_token, payment_amount, 100, sender=bob)
+
+
 def test_purchase_ripe_bond_with_lock_above_minimum(
     teller, setupRipeBonds, bob, alpha_token_whale, alpha_token, _test, ripe_token, ripe_gov_vault
 ):
@@ -3174,4 +3225,3 @@ def test_purchase_ripe_bond_rounding_errors(
     # Verify no tokens are stuck due to rounding
     bond_balance = alpha_token.balanceOf(bond_room.address)
     assert bond_balance == 0  # All should be transferred to endaoment
-

--- a/tests/core/creditEngine/test_credit_borrow.py
+++ b/tests/core/creditEngine/test_credit_borrow.py
@@ -897,6 +897,64 @@ def test_borrow_savings_green_enter_stab_pool(
     assert final_stab_pool_balance > 0  # should have sGREEN deposited in stability pool
 
 
+def test_borrow_savings_green_uses_preferred_stability_pool_pointer(
+    alpha_token,
+    alpha_token_whale,
+    bob,
+    setGeneralConfig,
+    setAssetConfig,
+    setGeneralDebtConfig,
+    performDeposit,
+    mock_price_source,
+    teller,
+    savings_green,
+    stability_pool,
+    alternate_stability_pool,
+    registerVault,
+    mission_control,
+    switchboard_alpha,
+):
+    preferred_id = registerVault(alternate_stability_pool, "Preferred Stability Pool")
+    setGeneralConfig()
+    setAssetConfig(alpha_token)
+    setAssetConfig(savings_green, [preferred_id])
+    setGeneralDebtConfig()
+    mission_control.setPreferredStabVaultId(preferred_id, sender=switchboard_alpha.address)
+
+    deposit_amount = 100 * EIGHTEEN_DECIMALS
+    performDeposit(bob, deposit_amount, alpha_token, alpha_token_whale)
+    mock_price_source.setPrice(alpha_token, EIGHTEEN_DECIMALS)
+
+    teller.borrow(50 * EIGHTEEN_DECIMALS, bob, True, True, sender=bob)
+    assert alternate_stability_pool.getTotalAmountForUser(bob, savings_green) > 0
+    assert stability_pool.getTotalAmountForUser(bob, savings_green) == 0
+
+
+def test_borrow_savings_green_fails_closed_when_preferred_pointer_is_unset(
+    alpha_token,
+    alpha_token_whale,
+    bob,
+    setGeneralConfig,
+    setAssetConfig,
+    setGeneralDebtConfig,
+    performDeposit,
+    mock_price_source,
+    teller,
+    savings_green,
+    mission_control,
+):
+    setGeneralConfig()
+    setAssetConfig(alpha_token)
+    setAssetConfig(savings_green, [1])
+    setGeneralDebtConfig()
+    performDeposit(bob, 100 * EIGHTEEN_DECIMALS, alpha_token, alpha_token_whale)
+    mock_price_source.setPrice(alpha_token, EIGHTEEN_DECIMALS)
+    mission_control.eval("self.preferredStabVaultId = 0")
+
+    with boa.reverts("invalid vault id"):
+        teller.borrow(50 * EIGHTEEN_DECIMALS, bob, True, True, sender=bob)
+
+
 def test_borrow_savings_green_no_stab_pool(
     alpha_token,
     alpha_token_whale,

--- a/tests/core/creditEngine/test_credit_redemptions.py
+++ b/tests/core/creditEngine/test_credit_redemptions.py
@@ -46,6 +46,19 @@ def _setup_backing_aware_redemption_position(
     return vault_id, alpha_amount, bravo_amount, debt_amount
 
 
+@pytest.fixture(scope="module")
+def credit_redeem_pointer_harness(credit_redeem):
+    credit_redeem.inject_function(
+        """
+@external
+def testHandleGreenForUser(_recipient: address, _amount: uint256):
+    a: addys.Addys = addys._getAddys()
+    self._handleGreenForUser(_recipient, _amount, True, True, a)
+        """
+    )
+    return credit_redeem
+
+
 def test_credit_redemption_basic(
     alpha_token,
     alpha_token_whale,
@@ -2084,6 +2097,45 @@ def test_credit_redemption_stability_pool_entry(
 
     # Alice's sGREEN balance should now be 0 (deposited into pool)
     assert savings_green.balanceOf(alice) == 0
+
+
+def test_credit_redeem_green_handler_uses_preferred_stability_pool_pointer(
+    credit_redeem_pointer_harness,
+    credit_engine,
+    alternate_stability_pool,
+    stability_pool,
+    registerVault,
+    mission_control,
+    switchboard_alpha,
+    green_token,
+    savings_green,
+    alice,
+    setGeneralConfig,
+    setAssetConfig,
+):
+    preferred_id = registerVault(alternate_stability_pool, "Preferred Stability Pool")
+    setGeneralConfig()
+    setAssetConfig(savings_green, [preferred_id])
+    mission_control.setPreferredStabVaultId(preferred_id, sender=switchboard_alpha.address)
+
+    amount = 10 * EIGHTEEN_DECIMALS
+    green_token.mint(
+        credit_redeem_pointer_harness.address,
+        amount,
+        sender=credit_engine.address,
+    )
+    credit_redeem_pointer_harness.inject.testHandleGreenForUser(alice, amount, sender=alice)
+    assert alternate_stability_pool.getTotalAmountForUser(alice, savings_green) > 0
+    assert stability_pool.getTotalAmountForUser(alice, savings_green) == 0
+
+    mission_control.eval("self.preferredStabVaultId = 0")
+    green_token.mint(
+        credit_redeem_pointer_harness.address,
+        amount,
+        sender=credit_engine.address,
+    )
+    with boa.reverts("invalid vault id"):
+        credit_redeem_pointer_harness.inject.testHandleGreenForUser(alice, amount, sender=alice)
 
 
 def test_credit_redemption_with_interest_accrual(

--- a/tests/core/humanResources/test_hr_other.py
+++ b/tests/core/humanResources/test_hr_other.py
@@ -476,6 +476,88 @@ def test_hr_refund_after_cancel_paycheck_paused(
         )
 
 
+def test_hr_ripe_routes_follow_core_governance_vault_pointer(
+    human_resources,
+    ripe_gov_vault,
+    alternate_ripe_gov_vault,
+    registerVault,
+    mission_control,
+    switchboard_alpha,
+    ripe_token,
+    ledger,
+    whale,
+    teller,
+    setupRipeGovVaultConfig,
+    deployedContributor,
+    setAssetConfig,
+    alice,
+):
+    setupRipeGovVaultConfig()
+    core_id = registerVault(alternate_ripe_gov_vault, "Core RipeGov")
+    setAssetConfig(ripe_token, _vaultIds=[core_id])
+    mission_control.setCoreRipeGovVaultId(core_id, sender=switchboard_alpha.address)
+    contributor_addr = deployedContributor()
+
+    assert not human_resources.hasRipeBalance(contributor_addr)
+    assert human_resources.cashRipeCheck(
+        50_000 * EIGHTEEN_DECIMALS,
+        500,
+        sender=contributor_addr,
+    )
+    assert human_resources.hasRipeBalance(contributor_addr)
+    assert ripe_gov_vault.getTotalAmountForUser(contributor_addr, ripe_token) == 0
+
+    transferred = human_resources.transferContributorRipeTokens(
+        alice,
+        200,
+        sender=contributor_addr,
+    )
+    assert transferred > 0
+    assert alternate_ripe_gov_vault.getTotalAmountForUser(alice, ripe_token) == transferred
+
+    deposit_amount = 1_000 * EIGHTEEN_DECIMALS
+    ripe_token.transfer(alternate_ripe_gov_vault, deposit_amount, sender=whale)
+    alternate_ripe_gov_vault.depositTokensInVault(
+        contributor_addr,
+        ripe_token,
+        deposit_amount,
+        sender=teller.address,
+    )
+    ripe_available_before = ledger.ripeAvailForHr()
+    human_resources.refundAfterCancelPaycheck(
+        25_000 * EIGHTEEN_DECIMALS,
+        True,
+        sender=contributor_addr,
+    )
+    assert ledger.ripeAvailForHr() == ripe_available_before + 25_000 * EIGHTEEN_DECIMALS
+    assert alternate_ripe_gov_vault.getTotalAmountForUser(contributor_addr, ripe_token) == 0
+
+
+def test_hr_ripe_routes_fail_closed_when_core_pointer_is_unset(
+    human_resources,
+    mission_control,
+    setupRipeGovVaultConfig,
+    deployedContributor,
+    alice,
+):
+    setupRipeGovVaultConfig()
+    contributor_addr = deployedContributor()
+    mission_control.eval("self.coreRipeGovVaultId = 0")
+
+    with boa.reverts("invalid vault id"):
+        human_resources.hasRipeBalance(contributor_addr)
+    with boa.reverts("invalid vault id"):
+        human_resources.transferContributorRipeTokens(alice, 200, sender=contributor_addr)
+    with boa.reverts("invalid vault id"):
+        human_resources.cashRipeCheck(50_000 * EIGHTEEN_DECIMALS, 500, sender=contributor_addr)
+    with boa.reverts("invalid vault id"):
+        human_resources.refundAfterCancelPaycheck(
+            25_000 * EIGHTEEN_DECIMALS,
+            True,
+            sender=contributor_addr,
+        )
+
+
 # Test getTotalClaimed
 
 

--- a/tests/core/lootbox/test_loot_claim.py
+++ b/tests/core/lootbox/test_loot_claim.py
@@ -1525,3 +1525,66 @@ def test_loot_claim_auto_stake_configuration_updates(
     assert second_claim > 0
     assert ripe_token.balanceOf(bob) == first_claim  # Wallet unchanged from first claim
     assert ripe_gov_vault.getTotalAmountForUser(bob, ripe_token) > 0  # Second claim went to vault
+
+
+def test_lootbox_auto_stake_uses_core_governance_vault_pointer(
+    bob,
+    setGeneralConfig,
+    setAssetConfig,
+    setRipeRewardsConfig,
+    performDeposit,
+    simple_erc20_vault,
+    vault_book,
+    lootbox,
+    teller,
+    ripe_token,
+    alpha_token,
+    alpha_token_whale,
+    mission_control,
+    switchboard_alpha,
+    ripe_gov_vault,
+    alternate_ripe_gov_vault,
+    registerVault,
+):
+    core_id = registerVault(alternate_ripe_gov_vault, "Core RipeGov")
+    setGeneralConfig()
+    setAssetConfig(alpha_token)
+    setAssetConfig(ripe_token, _vaultIds=[core_id])
+    setRipeRewardsConfig(_autoStakeRatio=100_00, _autoStakeDurationRatio=50_00)
+    mission_control.setRipeGovVaultConfig(
+        ripe_token,
+        100_00,
+        False,
+        (100, 1_000, 100_00, False, 0),
+        sender=switchboard_alpha.address,
+    )
+    mission_control.setCoreRipeGovVaultId(core_id, sender=switchboard_alpha.address)
+
+    performDeposit(bob, 100 * EIGHTEEN_DECIMALS, alpha_token, alpha_token_whale)
+    source_vault_id = vault_book.getRegId(simple_erc20_vault)
+    boa.env.time_travel(blocks=20)
+    lootbox.updateDepositPoints(
+        bob,
+        source_vault_id,
+        simple_erc20_vault,
+        alpha_token,
+        sender=teller.address,
+    )
+
+    claimed = teller.claimLoot(bob, False, sender=bob)
+    assert claimed > 0
+    assert alternate_ripe_gov_vault.getTotalAmountForUser(bob, ripe_token) > 0
+    assert ripe_gov_vault.getTotalAmountForUser(bob, ripe_token) == 0
+
+
+def test_lootbox_claim_routes_fail_closed_when_core_pointer_is_unset(
+    mission_control,
+    lootbox,
+    bob,
+    alpha_token,
+):
+    mission_control.eval("self.coreRipeGovVaultId = 0")
+
+    assert lootbox.getClaimableLoot(bob) == 0
+    with boa.reverts("invalid vault id"):
+        lootbox.getClaimableDepositLootForAsset(bob, 3, alpha_token)

--- a/tests/core/lootbox/test_loot_claim.py
+++ b/tests/core/lootbox/test_loot_claim.py
@@ -1588,3 +1588,133 @@ def test_lootbox_claim_routes_fail_closed_when_core_pointer_is_unset(
     assert lootbox.getClaimableLoot(bob) == 0
     with boa.reverts("invalid vault id"):
         lootbox.getClaimableDepositLootForAsset(bob, 3, alpha_token)
+
+
+def test_lootbox_borrow_auto_stake_uses_core_governance_vault_pointer(
+    bob,
+    setGeneralConfig,
+    setAssetConfig,
+    setRipeRewardsConfig,
+    ledger,
+    lootbox,
+    teller,
+    credit_engine,
+    createDebtTerms,
+    ripe_token,
+    mission_control,
+    switchboard_alpha,
+    ripe_gov_vault,
+    alternate_ripe_gov_vault,
+    registerVault,
+):
+    core_id = registerVault(alternate_ripe_gov_vault, "Borrow Loot Core RipeGov")
+    setGeneralConfig()
+    setAssetConfig(ripe_token, _vaultIds=[core_id])
+    setRipeRewardsConfig(
+        True,
+        _autoStakeRatio=100_00,
+        _autoStakeDurationRatio=50_00,
+    )
+    mission_control.setRipeGovVaultConfig(
+        ripe_token,
+        100_00,
+        False,
+        (100, 1_000, 100_00, False, 0),
+        sender=switchboard_alpha.address,
+    )
+    mission_control.setCoreRipeGovVaultId(core_id, sender=switchboard_alpha.address)
+
+    debt_terms = createDebtTerms()
+    user_debt = (
+        100 * EIGHTEEN_DECIMALS,
+        100 * EIGHTEEN_DECIMALS,
+        debt_terms,
+        0,
+        False,
+    )
+    ledger.setUserDebt(bob, user_debt, 0, (0, 0), sender=credit_engine.address)
+    lootbox.updateBorrowPoints(bob, sender=teller.address)
+    boa.env.time_travel(blocks=20)
+    lootbox.updateBorrowPoints(bob, sender=teller.address)
+
+    claimable = lootbox.getClaimableBorrowLoot(bob)
+    assert claimable > 0
+    assert lootbox.claimBorrowLoot(bob, sender=teller.address) == claimable
+    assert (
+        alternate_ripe_gov_vault.getTotalAmountForUser(bob, ripe_token)
+        == claimable
+    )
+    assert ripe_gov_vault.getTotalAmountForUser(bob, ripe_token) == 0
+    assert ripe_token.balanceOf(bob) == 0
+
+
+def test_lootbox_borrow_claim_unset_pointer_reverts_without_state_changes(
+    bob,
+    setGeneralConfig,
+    setRipeRewardsConfig,
+    ledger,
+    lootbox,
+    teller,
+    credit_engine,
+    createDebtTerms,
+    ripe_token,
+    mission_control,
+):
+    setGeneralConfig()
+    setRipeRewardsConfig(
+        True,
+        _autoStakeRatio=100_00,
+        _autoStakeDurationRatio=50_00,
+    )
+
+    debt_terms = createDebtTerms()
+    user_debt = (
+        100 * EIGHTEEN_DECIMALS,
+        100 * EIGHTEEN_DECIMALS,
+        debt_terms,
+        0,
+        False,
+    )
+    ledger.setUserDebt(bob, user_debt, 0, (0, 0), sender=credit_engine.address)
+    lootbox.updateBorrowPoints(bob, sender=teller.address)
+    boa.env.time_travel(blocks=20)
+    lootbox.updateBorrowPoints(bob, sender=teller.address)
+
+    claimable_before = lootbox.getClaimableBorrowLoot(bob)
+    user_points_before = ledger.userBorrowPoints(bob)
+    global_points_before = ledger.globalBorrowPoints()
+    rewards_available_before = ledger.ripeAvailForRewards()
+    supply_before = ripe_token.totalSupply()
+    user_balance_before = ripe_token.balanceOf(bob)
+    allowance_before = ripe_token.allowance(lootbox, teller)
+    assert claimable_before > 0
+
+    mission_control.eval("self.coreRipeGovVaultId = 0")
+    with boa.reverts("invalid vault id"):
+        lootbox.claimBorrowLoot(bob, sender=teller.address)
+
+    user_points_after = ledger.userBorrowPoints(bob)
+    global_points_after = ledger.globalBorrowPoints()
+    assert lootbox.getClaimableBorrowLoot(bob) == claimable_before
+    assert (
+        user_points_after.lastPrincipal,
+        user_points_after.points,
+        user_points_after.lastUpdate,
+    ) == (
+        user_points_before.lastPrincipal,
+        user_points_before.points,
+        user_points_before.lastUpdate,
+    )
+    assert (
+        global_points_after.lastPrincipal,
+        global_points_after.points,
+        global_points_after.lastUpdate,
+    ) == (
+        global_points_before.lastPrincipal,
+        global_points_before.points,
+        global_points_before.lastUpdate,
+    )
+    assert ledger.ripeAvailForRewards() == rewards_available_before
+    assert ripe_token.totalSupply() == supply_before
+    assert ripe_token.balanceOf(bob) == user_balance_before
+    assert ripe_token.allowance(lootbox, teller) == allowance_before

--- a/tests/core/lootbox/test_loot_deposit_points.py
+++ b/tests/core/lootbox/test_loot_deposit_points.py
@@ -70,6 +70,97 @@ def test_lootbox_deposit_point_routes_fail_closed_when_core_pointer_is_unset(
         )
 
 
+def test_lootbox_point_resets_use_dynamic_core_vault_precision(
+    alternate_ripe_gov_vault,
+    registerVault,
+    mission_control,
+    switchboard_alpha,
+    switchboard_delta,
+    ripe_token,
+    whale,
+    bob,
+    setGeneralConfig,
+    setAssetConfig,
+    setRipeRewardsConfig,
+    mock_price_source,
+    teller,
+    lootbox,
+    ledger,
+):
+    core_id = registerVault(alternate_ripe_gov_vault, "Reset Points Core RipeGov")
+    setGeneralConfig()
+    setAssetConfig(
+        ripe_token,
+        _vaultIds=[core_id],
+        _stakersPointsAlloc=10,
+        _voterPointsAlloc=20,
+    )
+    setRipeRewardsConfig(True)
+    mock_price_source.setPrice(ripe_token, EIGHTEEN_DECIMALS)
+    mission_control.setRipeGovVaultConfig(
+        ripe_token,
+        100_00,
+        False,
+        (100, 1_000, 100_00, False, 0),
+        sender=switchboard_alpha.address,
+    )
+    mission_control.setCoreRipeGovVaultId(core_id, sender=switchboard_alpha.address)
+
+    deposit_amount = 100 * EIGHTEEN_DECIMALS
+    ripe_token.transfer(bob, deposit_amount, sender=whale)
+    ripe_token.approve(teller, deposit_amount, sender=bob)
+    teller.depositIntoGovVault(
+        ripe_token,
+        deposit_amount,
+        100,
+        bob,
+        sender=bob,
+    )
+    lootbox.updateDepositPoints(
+        bob,
+        core_id,
+        alternate_ripe_gov_vault,
+        ripe_token,
+        sender=teller.address,
+    )
+    boa.env.time_travel(blocks=20)
+    lootbox.updateDepositPoints(
+        bob,
+        core_id,
+        alternate_ripe_gov_vault,
+        ripe_token,
+        sender=teller.address,
+    )
+
+    user_points_before = ledger.userDepositPoints(bob, core_id, ripe_token)
+    asset_points_before = ledger.assetDepositPoints(core_id, ripe_token)
+    assert user_points_before.balancePoints > 0
+    assert asset_points_before.ripeStakerPoints > 0
+    assert asset_points_before.ripeVotePoints > 0
+
+    lootbox.resetUserBalancePoints(
+        bob,
+        ripe_token,
+        core_id,
+        sender=switchboard_delta.address,
+    )
+    assert ledger.userDepositPoints(bob, core_id, ripe_token).balancePoints == 0
+
+    lootbox.resetAssetPoints(
+        ripe_token,
+        core_id,
+        sender=switchboard_delta.address,
+    )
+    asset_points_after = ledger.assetDepositPoints(core_id, ripe_token)
+    assert asset_points_after.ripeStakerPoints == 0
+    assert asset_points_after.ripeVotePoints == 0
+    assert asset_points_after.ripeGenPoints == 0
+    assert (
+        alternate_ripe_gov_vault.getTotalAmountForUser(bob, ripe_token)
+        == deposit_amount
+    )
+
+
 def test_loot_deposit_points_first_save(
     alpha_token,
     alpha_token_whale,

--- a/tests/core/lootbox/test_loot_deposit_points.py
+++ b/tests/core/lootbox/test_loot_deposit_points.py
@@ -4,6 +4,72 @@ import pytest
 from constants import EIGHTEEN_DECIMALS, ZERO_ADDRESS
 
 
+def test_ripe_gov_precision_exception_follows_core_vault_pointer(
+    alternate_ripe_gov_vault,
+    registerVault,
+    mission_control,
+    switchboard_alpha,
+    ripe_token,
+    whale,
+    bob,
+    setGeneralConfig,
+    setAssetConfig,
+    setRipeRewardsConfig,
+    teller,
+    lootbox,
+):
+    core_id = registerVault(alternate_ripe_gov_vault, "Core RipeGov")
+    setGeneralConfig()
+    setAssetConfig(ripe_token, _vaultIds=[core_id])
+    setRipeRewardsConfig(True)
+    mission_control.setRipeGovVaultConfig(
+        ripe_token,
+        100_00,
+        False,
+        (100, 1_000, 100_00, False, 0),
+        sender=switchboard_alpha.address,
+    )
+    mission_control.setCoreRipeGovVaultId(core_id, sender=switchboard_alpha.address)
+
+    deposit_amount = 100 * EIGHTEEN_DECIMALS
+    ripe_token.transfer(bob, deposit_amount, sender=whale)
+    ripe_token.approve(teller, deposit_amount, sender=bob)
+    teller.depositIntoGovVault(ripe_token, deposit_amount, 100, bob, sender=bob)
+
+    user_points, asset_points, _ = lootbox.getLatestDepositPoints(bob, core_id, ripe_token)
+    expected_governance_share = (
+        alternate_ripe_gov_vault.userGovData(bob, ripe_token).lastShares // EIGHTEEN_DECIMALS
+    )
+    assert asset_points.precision == 10 ** 9
+    assert user_points.lastBalance == expected_governance_share
+
+    mission_control.setCoreRipeGovVaultId(2, sender=switchboard_alpha.address)
+    noncore_user_points, _, _ = lootbox.getLatestDepositPoints(bob, core_id, ripe_token)
+    assert noncore_user_points.lastBalance == expected_governance_share // asset_points.precision
+
+
+def test_lootbox_deposit_point_routes_fail_closed_when_core_pointer_is_unset(
+    mission_control,
+    lootbox,
+    teller,
+    simple_erc20_vault,
+    alpha_token,
+    bob,
+):
+    mission_control.eval("self.coreRipeGovVaultId = 0")
+
+    with boa.reverts("invalid vault id"):
+        lootbox.getLatestDepositPoints(bob, 3, alpha_token)
+    with boa.reverts("invalid vault id"):
+        lootbox.updateDepositPoints(
+            bob,
+            3,
+            simple_erc20_vault,
+            alpha_token,
+            sender=teller.address,
+        )
+
+
 def test_loot_deposit_points_first_save(
     alpha_token,
     alpha_token_whale,
@@ -2770,5 +2836,3 @@ def test_reset_asset_points_multiple_vaults(
     assert ap2_after.ripeStakerPoints == ap2_before.ripeStakerPoints
     assert ap2_after.ripeVotePoints == ap2_before.ripeVotePoints
     assert ap2_after.ripeGenPoints == ap2_before.ripeGenPoints
-
-

--- a/tests/core/teller/test_teller_deposit.py
+++ b/tests/core/teller/test_teller_deposit.py
@@ -1303,6 +1303,62 @@ def test_teller_get_savings_green_and_enter_stab_pool_basic(
     assert green_token.allowance(teller, savings_green) == 0
 
 
+def test_teller_conversion_uses_preferred_stability_pool_pointer(
+    alternate_stability_pool,
+    stability_pool,
+    registerVault,
+    mission_control,
+    switchboard_alpha,
+    green_token,
+    savings_green,
+    whale,
+    bob,
+    setGeneralConfig,
+    setAssetConfig,
+    teller,
+):
+    preferred_id = registerVault(alternate_stability_pool, "Preferred Stability Pool")
+    setGeneralConfig()
+    setAssetConfig(savings_green, [preferred_id])
+    mission_control.setPreferredStabVaultId(preferred_id, sender=switchboard_alpha.address)
+
+    deposit_amount = 100 * EIGHTEEN_DECIMALS
+    green_token.transfer(bob, deposit_amount, sender=whale)
+    green_token.approve(teller.address, deposit_amount, sender=bob)
+    sgreen_amount = teller.convertToSavingsGreenAndDepositIntoStabPool(
+        bob,
+        deposit_amount,
+        sender=bob,
+    )
+
+    log = filter_logs(teller, "TellerDeposit")[0]
+    assert log.vaultId == preferred_id
+    assert log.vaultAddr == alternate_stability_pool.address
+    assert alternate_stability_pool.getTotalAmountForUser(bob, savings_green) == sgreen_amount
+    assert stability_pool.getTotalAmountForUser(bob, savings_green) == 0
+
+
+def test_teller_conversion_fails_closed_when_preferred_pointer_is_unset(
+    mission_control,
+    green_token,
+    savings_green,
+    whale,
+    bob,
+    setGeneralConfig,
+    setAssetConfig,
+    teller,
+):
+    setGeneralConfig()
+    setAssetConfig(savings_green, [1])
+    mission_control.eval("self.preferredStabVaultId = 0")
+
+    deposit_amount = 100 * EIGHTEEN_DECIMALS
+    green_token.transfer(bob, deposit_amount, sender=whale)
+    green_token.approve(teller.address, deposit_amount, sender=bob)
+    with boa.reverts("invalid vault id"):
+        teller.convertToSavingsGreenAndDepositIntoStabPool(bob, deposit_amount, sender=bob)
+
+
 def test_teller_get_savings_green_and_enter_stab_pool_insufficient_funds(
     stability_pool,
     green_token,
@@ -3286,4 +3342,4 @@ def test_m1_teller_runtime_size_dual_guard():
     runtime = bytes.fromhex(output[2:])
     assert len(runtime) > 0
     assert len(runtime) <= 24_576
-    assert len(runtime) <= 24_082
+    assert len(runtime) <= 24_326

--- a/tests/data/test_mission_control.py
+++ b/tests/data/test_mission_control.py
@@ -106,6 +106,16 @@ def sample_ripe_rewards_config():
     )
 
 
+@pytest.fixture
+def fresh_mission_control(ripe_hq, defaults):
+    return boa.load(
+        "contracts/data/MissionControl.vy",
+        ripe_hq,
+        defaults,
+        name="fresh_mission_control",
+    )
+
+
 ####################
 # Initial State    #
 ####################
@@ -120,6 +130,59 @@ def test_mission_control_initial_state(mission_control):
     assert not mission_control.isPaused()
     assert not mission_control.canMintGreen()
     assert not mission_control.canMintRipe()
+
+
+def test_vault_id_pointers_initialize_to_zero(fresh_mission_control):
+    assert fresh_mission_control.coreRipeGovVaultId() == 0
+    assert fresh_mission_control.preferredStabVaultId() == 0
+
+
+def test_every_registered_switchboard_can_set_exact_nonzero_vault_ids(
+    fresh_mission_control,
+    switchboard_alpha,
+    switchboard_bravo,
+    switchboard_charlie,
+    switchboard_delta,
+    switchboard_echo,
+):
+    switchboards = [
+        switchboard_alpha,
+        switchboard_bravo,
+        switchboard_charlie,
+        switchboard_delta,
+        switchboard_echo,
+    ]
+
+    for offset, switchboard in enumerate(switchboards, start=1):
+        core_id = 100 + offset
+        preferred_id = 200 + offset
+        fresh_mission_control.setCoreRipeGovVaultId(core_id, sender=switchboard.address)
+        assert fresh_mission_control.coreRipeGovVaultId() == core_id
+        assert fresh_mission_control.get_logs() == []
+
+        fresh_mission_control.setPreferredStabVaultId(preferred_id, sender=switchboard.address)
+        assert fresh_mission_control.preferredStabVaultId() == preferred_id
+        assert fresh_mission_control.get_logs() == []
+
+
+@pytest.mark.parametrize("setter_name", ["setCoreRipeGovVaultId", "setPreferredStabVaultId"])
+def test_vault_id_pointer_setters_reject_zero(
+    fresh_mission_control,
+    switchboard_charlie,
+    setter_name,
+):
+    with boa.reverts("invalid vault id"):
+        getattr(fresh_mission_control, setter_name)(0, sender=switchboard_charlie.address)
+
+
+@pytest.mark.parametrize("setter_name", ["setCoreRipeGovVaultId", "setPreferredStabVaultId"])
+def test_vault_id_pointer_setters_reject_non_switchboards(
+    fresh_mission_control,
+    alice,
+    setter_name,
+):
+    with boa.reverts("no perms"):
+        getattr(fresh_mission_control, setter_name)(1, sender=alice)
 
 
 #######################

--- a/tests/test_vault_pointer_runtime_sizes.py
+++ b/tests/test_vault_pointer_runtime_sizes.py
@@ -1,0 +1,37 @@
+EIP170_LIMIT = 24_576
+
+
+def test_pointer_changed_contracts_fit_eip170_deployed_runtime_limit(
+    mission_control,
+    switchboard_alpha,
+    switchboard_bravo,
+    switchboard_charlie,
+    teller,
+    bond_room,
+    lootbox,
+    human_resources,
+    credit_engine,
+    credit_redeem,
+    stability_pool,
+):
+    deployed_runtime_bytes = {
+        "MissionControl": len(mission_control.env.get_code(mission_control.address)),
+        "SwitchboardAlpha": len(switchboard_alpha.env.get_code(switchboard_alpha.address)),
+        "SwitchboardBravo": len(switchboard_bravo.env.get_code(switchboard_bravo.address)),
+        "SwitchboardCharlie": len(switchboard_charlie.env.get_code(switchboard_charlie.address)),
+        "Teller": len(teller.env.get_code(teller.address)),
+        "BondRoom": len(bond_room.env.get_code(bond_room.address)),
+        "Lootbox": len(lootbox.env.get_code(lootbox.address)),
+        "HumanResources": len(human_resources.env.get_code(human_resources.address)),
+        "CreditEngine": len(credit_engine.env.get_code(credit_engine.address)),
+        "CreditRedeem": len(credit_redeem.env.get_code(credit_redeem.address)),
+        "StabilityPool": len(stability_pool.env.get_code(stability_pool.address)),
+    }
+    print("DEPLOYED_RUNTIME_BYTES", deployed_runtime_bytes)
+
+    oversized = {
+        name: size
+        for name, size in deployed_runtime_bytes.items()
+        if size > EIP170_LIMIT
+    }
+    assert not oversized, f"EIP-170 runtime limit exceeded: {oversized}"

--- a/tests/vaults/modules/test_stab_vault_claims.py
+++ b/tests/vaults/modules/test_stab_vault_claims.py
@@ -3717,3 +3717,133 @@ def test_stability_pool_auto_deposit_rejects_its_own_dynamic_vault_id(
     )
     assert bravo_token.balanceOf(bob) > 0
     assert alternate_stability_pool.getTotalAmountForUser(bob, bravo_token) == 0
+
+
+def test_preferred_pointer_rotation_preserves_legacy_pool_state_and_explicit_access(
+    stability_pool,
+    alternate_stability_pool,
+    registerVault,
+    mission_control,
+    switchboard_alpha,
+    alpha_token,
+    bravo_token,
+    green_token,
+    savings_green,
+    alpha_token_whale,
+    bravo_token_whale,
+    whale,
+    bob,
+    teller,
+    auction_house,
+    mock_price_source,
+    setGeneralConfig,
+    setAssetConfig,
+):
+    preferred_id = registerVault(
+        alternate_stability_pool,
+        "Replacement Preferred Stability Pool",
+    )
+    setGeneralConfig()
+    setAssetConfig(alpha_token, _vaultIds=[1], _stakersPointsAlloc=0)
+    setAssetConfig(bravo_token, _vaultIds=[1], _stakersPointsAlloc=0)
+    setAssetConfig(savings_green, _vaultIds=[1, preferred_id])
+    mock_price_source.setPrice(alpha_token, EIGHTEEN_DECIMALS)
+    mock_price_source.setPrice(bravo_token, EIGHTEEN_DECIMALS)
+
+    legacy_deposit = 100 * EIGHTEEN_DECIMALS
+    alpha_token.transfer(stability_pool, legacy_deposit, sender=alpha_token_whale)
+    stability_pool.depositTokensInVault(
+        bob,
+        alpha_token,
+        legacy_deposit,
+        sender=teller.address,
+    )
+
+    swapped_amount = 40 * EIGHTEEN_DECIMALS
+    claimable_amount = 60 * EIGHTEEN_DECIMALS
+    bravo_token.transfer(stability_pool, claimable_amount, sender=bravo_token_whale)
+    stability_pool.swapForLiquidatedCollateral(
+        alpha_token,
+        swapped_amount,
+        bravo_token,
+        claimable_amount,
+        ZERO_ADDRESS,
+        alpha_token,
+        savings_green,
+        sender=auction_house.address,
+    )
+
+    legacy_position_before = stability_pool.getTotalAmountForUser(bob, alpha_token)
+    pair_claimable_before = stability_pool.claimableBalances(alpha_token, bravo_token)
+    total_claimable_before = stability_pool.totalClaimableBalances(bravo_token)
+    active_claim_assets_before = stability_pool.numClaimableAssets(alpha_token)
+    assert legacy_position_before > 0
+    assert pair_claimable_before > 0
+
+    mission_control.setPreferredStabVaultId(
+        preferred_id,
+        sender=switchboard_alpha.address,
+    )
+
+    assert (
+        stability_pool.getTotalAmountForUser(bob, alpha_token)
+        == legacy_position_before
+    )
+    assert (
+        stability_pool.claimableBalances(alpha_token, bravo_token)
+        == pair_claimable_before
+    )
+    assert stability_pool.totalClaimableBalances(bravo_token) == total_claimable_before
+    assert stability_pool.numClaimableAssets(alpha_token) == active_claim_assets_before
+
+    new_deposit = 25 * EIGHTEEN_DECIMALS
+    green_token.transfer(bob, new_deposit, sender=whale)
+    green_token.approve(teller, new_deposit, sender=bob)
+    sgreen_deposited = teller.convertToSavingsGreenAndDepositIntoStabPool(
+        bob,
+        new_deposit,
+        sender=bob,
+    )
+    assert (
+        alternate_stability_pool.getTotalAmountForUser(bob, savings_green)
+        == sgreen_deposited
+    )
+    assert stability_pool.getTotalAmountForUser(bob, savings_green) == 0
+    assert (
+        stability_pool.getTotalAmountForUser(bob, alpha_token)
+        == legacy_position_before
+    )
+    assert (
+        stability_pool.claimableBalances(alpha_token, bravo_token)
+        == pair_claimable_before
+    )
+
+    bravo_balance_before = bravo_token.balanceOf(bob)
+    claimed_usd_value = teller.claimFromStabilityPool(
+        1,
+        alpha_token,
+        bravo_token,
+        MAX_UINT256,
+        bob,
+        False,
+        sender=bob,
+    )
+    assert claimed_usd_value > 0
+    assert bravo_token.balanceOf(bob) > bravo_balance_before
+
+    legacy_remaining = stability_pool.getTotalAmountForUser(bob, alpha_token)
+    assert legacy_remaining > 0
+    withdrawn = teller.withdraw(
+        alpha_token,
+        legacy_remaining,
+        bob,
+        stability_pool,
+        1,
+        sender=bob,
+    )
+    assert 0 <= legacy_remaining - withdrawn <= 1
+    assert stability_pool.getTotalAmountForUser(bob, alpha_token) == 0
+    assert (
+        alternate_stability_pool.getTotalAmountForUser(bob, savings_green)
+        == sgreen_deposited
+    )

--- a/tests/vaults/modules/test_stab_vault_claims.py
+++ b/tests/vaults/modules/test_stab_vault_claims.py
@@ -3565,3 +3565,155 @@ def test_stab_vault_claims_dust_different_price_levels(
     # Balance should remain
     remaining = stability_pool.claimableBalances(alpha_token, bravo_token)
     assert remaining > 0
+
+
+def test_stability_pool_ripe_rewards_use_core_governance_vault_pointer(
+    stability_pool,
+    alternate_ripe_gov_vault,
+    registerVault,
+    mission_control,
+    switchboard_alpha,
+    alpha_token,
+    bravo_token,
+    alpha_token_whale,
+    bravo_token_whale,
+    bob,
+    teller,
+    auction_house,
+    mock_price_source,
+    vault_book,
+    savings_green,
+    ripe_token,
+    ripe_gov_vault,
+    setAssetConfig,
+    setupStabPoolClaimsRewards,
+):
+    setupStabPoolClaimsRewards(_ripePerDollar=EIGHTEEN_DECIMALS // 10)
+    core_id = registerVault(alternate_ripe_gov_vault, "Core RipeGov")
+    setAssetConfig(ripe_token, _vaultIds=[core_id])
+    setAssetConfig(bravo_token)
+    mission_control.setCoreRipeGovVaultId(core_id, sender=switchboard_alpha.address)
+    mock_price_source.setPrice(alpha_token, EIGHTEEN_DECIMALS)
+    mock_price_source.setPrice(bravo_token, EIGHTEEN_DECIMALS)
+    mock_price_source.setPrice(ripe_token, EIGHTEEN_DECIMALS)
+
+    deposit_amount = 100 * EIGHTEEN_DECIMALS
+    alpha_token.transfer(stability_pool, deposit_amount, sender=alpha_token_whale)
+    stability_pool.depositTokensInVault(bob, alpha_token, deposit_amount, sender=teller.address)
+    claimable_amount = 150 * EIGHTEEN_DECIMALS
+    bravo_token.transfer(stability_pool, claimable_amount, sender=bravo_token_whale)
+    stability_pool.swapForLiquidatedCollateral(
+        alpha_token,
+        deposit_amount,
+        bravo_token,
+        claimable_amount,
+        ZERO_ADDRESS,
+        alpha_token,
+        savings_green,
+        sender=auction_house.address,
+    )
+
+    vault_id = vault_book.getRegId(stability_pool)
+    teller.claimFromStabilityPool(vault_id, alpha_token, bravo_token, sender=bob)
+    assert alternate_ripe_gov_vault.getTotalAmountForUser(bob, ripe_token) > 0
+    assert ripe_gov_vault.getTotalAmountForUser(bob, ripe_token) == 0
+
+
+def test_stability_pool_ripe_rewards_fail_closed_when_core_pointer_is_unset(
+    stability_pool,
+    mission_control,
+    alpha_token,
+    bravo_token,
+    alpha_token_whale,
+    bravo_token_whale,
+    bob,
+    teller,
+    auction_house,
+    mock_price_source,
+    vault_book,
+    savings_green,
+    ripe_token,
+    setAssetConfig,
+    setupStabPoolClaimsRewards,
+):
+    setupStabPoolClaimsRewards(_ripePerDollar=EIGHTEEN_DECIMALS // 10)
+    setAssetConfig(bravo_token)
+    mock_price_source.setPrice(alpha_token, EIGHTEEN_DECIMALS)
+    mock_price_source.setPrice(bravo_token, EIGHTEEN_DECIMALS)
+    mock_price_source.setPrice(ripe_token, EIGHTEEN_DECIMALS)
+    mission_control.eval("self.coreRipeGovVaultId = 0")
+
+    deposit_amount = 100 * EIGHTEEN_DECIMALS
+    alpha_token.transfer(stability_pool, deposit_amount, sender=alpha_token_whale)
+    stability_pool.depositTokensInVault(bob, alpha_token, deposit_amount, sender=teller.address)
+    claimable_amount = 150 * EIGHTEEN_DECIMALS
+    bravo_token.transfer(stability_pool, claimable_amount, sender=bravo_token_whale)
+    stability_pool.swapForLiquidatedCollateral(
+        alpha_token,
+        deposit_amount,
+        bravo_token,
+        claimable_amount,
+        ZERO_ADDRESS,
+        alpha_token,
+        savings_green,
+        sender=auction_house.address,
+    )
+
+    vault_id = vault_book.getRegId(stability_pool)
+    with boa.reverts("invalid vault id"):
+        teller.claimFromStabilityPool(vault_id, alpha_token, bravo_token, sender=bob)
+
+
+def test_stability_pool_auto_deposit_rejects_its_own_dynamic_vault_id(
+    alternate_stability_pool,
+    registerVault,
+    alpha_token,
+    bravo_token,
+    alpha_token_whale,
+    bravo_token_whale,
+    bob,
+    teller,
+    auction_house,
+    mock_price_source,
+    savings_green,
+    setGeneralConfig,
+    setAssetConfig,
+):
+    pool_id = registerVault(alternate_stability_pool, "Secondary Stability Pool")
+    setGeneralConfig()
+    setAssetConfig(bravo_token, _vaultIds=[pool_id])
+    mock_price_source.setPrice(alpha_token, EIGHTEEN_DECIMALS)
+    mock_price_source.setPrice(bravo_token, EIGHTEEN_DECIMALS)
+
+    deposit_amount = 100 * EIGHTEEN_DECIMALS
+    alpha_token.transfer(alternate_stability_pool, deposit_amount, sender=alpha_token_whale)
+    alternate_stability_pool.depositTokensInVault(
+        bob,
+        alpha_token,
+        deposit_amount,
+        sender=teller.address,
+    )
+    claimable_amount = 150 * EIGHTEEN_DECIMALS
+    bravo_token.transfer(alternate_stability_pool, claimable_amount, sender=bravo_token_whale)
+    alternate_stability_pool.swapForLiquidatedCollateral(
+        alpha_token,
+        deposit_amount,
+        bravo_token,
+        claimable_amount,
+        ZERO_ADDRESS,
+        alpha_token,
+        savings_green,
+        sender=auction_house.address,
+    )
+
+    teller.claimFromStabilityPool(
+        pool_id,
+        alpha_token,
+        bravo_token,
+        MAX_UINT256,
+        bob,
+        True,
+        sender=bob,
+    )
+    assert bravo_token.balanceOf(bob) > 0
+    assert alternate_stability_pool.getTotalAmountForUser(bob, bravo_token) == 0

--- a/tests/vaults/test_ripe_gov_vault.py
+++ b/tests/vaults/test_ripe_gov_vault.py
@@ -2567,3 +2567,64 @@ def test_depositIntoGovVault_lock_duration_capped(
     expected_unlock = boa.env.evm.patch.block_number + 1000  # maxLockDuration
     assert userData.unlock == expected_unlock
 
+
+def test_teller_governance_routes_follow_core_vault_pointer(
+    teller,
+    ripe_gov_vault,
+    alternate_ripe_gov_vault,
+    registerVault,
+    mission_control,
+    switchboard_alpha,
+    ripe_token,
+    whale,
+    setupRipeGovVaultConfig,
+    setGeneralConfig,
+    setAssetConfig,
+):
+    core_id = registerVault(alternate_ripe_gov_vault, "Core RipeGov")
+    setupRipeGovVaultConfig()
+    setGeneralConfig()
+    setAssetConfig(ripe_token, _vaultIds=[core_id])
+    mission_control.setCoreRipeGovVaultId(core_id, sender=switchboard_alpha.address)
+
+    deposit_amount = 100 * EIGHTEEN_DECIMALS
+    ripe_token.approve(teller, deposit_amount, sender=whale)
+    assert teller.depositIntoGovVault(
+        ripe_token,
+        deposit_amount,
+        500,
+        whale,
+        sender=whale,
+    ) == deposit_amount
+    assert alternate_ripe_gov_vault.getTotalAmountForUser(whale, ripe_token) == deposit_amount
+    assert ripe_gov_vault.getTotalAmountForUser(whale, ripe_token) == 0
+
+    teller.adjustLock(ripe_token, 800, whale, sender=whale)
+    adjusted = alternate_ripe_gov_vault.userGovData(whale, ripe_token)
+    assert adjusted.unlock == boa.env.evm.patch.block_number + 800
+
+    teller.releaseLock(ripe_token, whale, sender=whale)
+    released = alternate_ripe_gov_vault.userGovData(whale, ripe_token)
+    assert released.unlock == 0
+
+
+def test_teller_governance_routes_fail_closed_when_core_pointer_is_unset(
+    teller,
+    mission_control,
+    ripe_token,
+    whale,
+    setupRipeGovVaultConfig,
+    setGeneralConfig,
+):
+    setupRipeGovVaultConfig()
+    setGeneralConfig()
+    mission_control.eval("self.coreRipeGovVaultId = 0")
+
+    deposit_amount = 100 * EIGHTEEN_DECIMALS
+    ripe_token.approve(teller, deposit_amount, sender=whale)
+    with boa.reverts("invalid vault id"):
+        teller.depositIntoGovVault(ripe_token, deposit_amount, 0, whale, sender=whale)
+    with boa.reverts("invalid vault id"):
+        teller.adjustLock(ripe_token, 500, whale, sender=whale)
+    with boa.reverts("invalid vault id"):
+        teller.releaseLock(ripe_token, whale, sender=whale)

--- a/tests/vaults/test_ripe_gov_vault.py
+++ b/tests/vaults/test_ripe_gov_vault.py
@@ -2628,3 +2628,157 @@ def test_teller_governance_routes_fail_closed_when_core_pointer_is_unset(
         teller.adjustLock(ripe_token, 500, whale, sender=whale)
     with boa.reverts("invalid vault id"):
         teller.releaseLock(ripe_token, whale, sender=whale)
+
+
+def test_core_pointer_rotation_preserves_legacy_position_points_and_explicit_exit(
+    teller,
+    ripe_gov_vault,
+    alternate_ripe_gov_vault,
+    registerVault,
+    mission_control,
+    switchboard_alpha,
+    ripe_token,
+    whale,
+    setupRipeGovVaultConfig,
+    setGeneralConfig,
+    setAssetConfig,
+    setRipeRewardsConfig,
+    mock_price_source,
+    lootbox,
+    ledger,
+):
+    core_id = registerVault(alternate_ripe_gov_vault, "Replacement Core RipeGov")
+    setupRipeGovVaultConfig()
+    setGeneralConfig()
+    setAssetConfig(ripe_token, _vaultIds=[2, core_id])
+    setRipeRewardsConfig(True)
+    mock_price_source.setPrice(ripe_token, EIGHTEEN_DECIMALS)
+
+    legacy_amount = 100 * EIGHTEEN_DECIMALS
+    ripe_token.approve(teller, legacy_amount, sender=whale)
+    assert teller.depositIntoGovVault(
+        ripe_token,
+        legacy_amount,
+        100,
+        whale,
+        sender=whale,
+    ) == legacy_amount
+
+    boa.env.time_travel(blocks=20)
+    lootbox.updateDepositPoints(
+        whale,
+        2,
+        ripe_gov_vault,
+        ripe_token,
+        sender=teller.address,
+    )
+
+    legacy_gov_before = ripe_gov_vault.userGovData(whale, ripe_token)
+    legacy_points_before = ledger.userDepositPoints(whale, 2, ripe_token)
+    legacy_asset_points_before = ledger.assetDepositPoints(2, ripe_token)
+    global_points_before = ledger.globalDepositPoints()
+    asset_config_before = mission_control.assetConfig(ripe_token)
+    assert legacy_points_before.balancePoints > 0
+
+    gov_snapshot = (
+        legacy_gov_before.govPoints,
+        legacy_gov_before.lastShares,
+        legacy_gov_before.lastPointsUpdate,
+        legacy_gov_before.unlock,
+    )
+    user_points_snapshot = (
+        legacy_points_before.balancePoints,
+        legacy_points_before.lastBalance,
+        legacy_points_before.lastUpdate,
+    )
+    asset_points_snapshot = (
+        legacy_asset_points_before.balancePoints,
+        legacy_asset_points_before.lastBalance,
+        legacy_asset_points_before.lastUsdValue,
+        legacy_asset_points_before.ripeStakerPoints,
+        legacy_asset_points_before.ripeVotePoints,
+        legacy_asset_points_before.ripeGenPoints,
+        legacy_asset_points_before.lastUpdate,
+        legacy_asset_points_before.precision,
+    )
+    global_points_snapshot = (
+        global_points_before.lastUsdValue,
+        global_points_before.ripeStakerPoints,
+        global_points_before.ripeVotePoints,
+        global_points_before.ripeGenPoints,
+        global_points_before.lastUpdate,
+    )
+
+    mission_control.setCoreRipeGovVaultId(core_id, sender=switchboard_alpha.address)
+
+    legacy_gov_after = ripe_gov_vault.userGovData(whale, ripe_token)
+    legacy_points_after = ledger.userDepositPoints(whale, 2, ripe_token)
+    legacy_asset_points_after = ledger.assetDepositPoints(2, ripe_token)
+    global_points_after = ledger.globalDepositPoints()
+    asset_config_after = mission_control.assetConfig(ripe_token)
+
+    assert ripe_gov_vault.getTotalAmountForUser(whale, ripe_token) == legacy_amount
+    assert (
+        legacy_gov_after.govPoints,
+        legacy_gov_after.lastShares,
+        legacy_gov_after.lastPointsUpdate,
+        legacy_gov_after.unlock,
+    ) == gov_snapshot
+    assert (
+        legacy_points_after.balancePoints,
+        legacy_points_after.lastBalance,
+        legacy_points_after.lastUpdate,
+    ) == user_points_snapshot
+    assert (
+        legacy_asset_points_after.balancePoints,
+        legacy_asset_points_after.lastBalance,
+        legacy_asset_points_after.lastUsdValue,
+        legacy_asset_points_after.ripeStakerPoints,
+        legacy_asset_points_after.ripeVotePoints,
+        legacy_asset_points_after.ripeGenPoints,
+        legacy_asset_points_after.lastUpdate,
+        legacy_asset_points_after.precision,
+    ) == asset_points_snapshot
+    assert (
+        global_points_after.lastUsdValue,
+        global_points_after.ripeStakerPoints,
+        global_points_after.ripeVotePoints,
+        global_points_after.ripeGenPoints,
+        global_points_after.lastUpdate,
+    ) == global_points_snapshot
+    assert asset_config_after.stakersPointsAlloc == asset_config_before.stakersPointsAlloc
+    assert asset_config_after.voterPointsAlloc == asset_config_before.voterPointsAlloc
+
+    replacement_amount = 60 * EIGHTEEN_DECIMALS
+    ripe_token.approve(teller, replacement_amount, sender=whale)
+    assert teller.depositIntoGovVault(
+        ripe_token,
+        replacement_amount,
+        100,
+        whale,
+        sender=whale,
+    ) == replacement_amount
+    assert ripe_gov_vault.getTotalAmountForUser(whale, ripe_token) == legacy_amount
+    assert (
+        alternate_ripe_gov_vault.getTotalAmountForUser(whale, ripe_token)
+        == replacement_amount
+    )
+
+    legacy_unlock = ripe_gov_vault.userGovData(whale, ripe_token).unlock
+    if boa.env.evm.patch.block_number <= legacy_unlock:
+        boa.env.time_travel(
+            blocks=legacy_unlock - boa.env.evm.patch.block_number + 1
+        )
+    assert teller.withdraw(
+        ripe_token,
+        legacy_amount,
+        whale,
+        ripe_gov_vault,
+        2,
+        sender=whale,
+    ) == legacy_amount
+    assert ripe_gov_vault.getTotalAmountForUser(whale, ripe_token) == 0
+    assert (
+        alternate_ripe_gov_vault.getTotalAmountForUser(whale, ripe_token)
+        == replacement_amount
+    )


### PR DESCRIPTION
## Summary

- Add MissionControl pointers for the core RIPE governance vault and preferred Stability Pool vault.
- Require both pointers to be nonzero, registered, type-correct vault IDs in Switchboard Alpha, Bravo, and Charlie flows.
- Route governance staking, lock management, rewards, bonds, HR positions, and automatic sGREEN deposits through the configured pointers.
- Preserve CreditEngine STABILITY_POOL_ID only for the existing legacy never-collateral classification; automatic deposits use the preferred pointer.
- Add comprehensive pointer, rotation, fail-closed, authorization, reward-accounting, fixture, and runtime-size coverage.

## Semantics and scope

- Vault ID zero is invalid and means unset. Pointer-dependent operations fail closed until both IDs are configured correctly.
- Generic explicit-ID Teller deposit and withdrawal behavior is unchanged.
- This PR does not migrate positions or rewards and does not deploy, register, configure, activate, or rotate any vault.
- Rebased as two commits onto current origin/rh at 2c5a6de75c3c5e4873814c9d9d7686e55bc365e3, including the merged StabilityPool hardening work.

## Validation

- Controlling specification SHA-256: 2866593acdccdce17b597fa2dfd3ea976de2a460b0d829e9a536172f963bfd6c.
- Current-base hardening gate: all 11 new feature cases are green. Ten passed in the initial focused run; the one StabilityPool assertion was bounded to its observed one-wei full-exit rounding and passed on its single-case rerun.
- The new cases cover dual-vault coexistence, exact pointer-change state invariance, explicit legacy exit and claim paths, invalid and disabled VaultBook rebinding during Charlie execution, dynamic-core Lootbox point resets, borrow-reward auto-staking, and unset-pointer revert atomicity.
- Current-base deployed-runtime gate: 1 passed.
- Earlier pointer-focused gate before the StabilityPool base update: 44 passed, 935 deselected.
- Earlier complete directly modified-module gate before the StabilityPool base update: 975 passed, 4 deselected. The four deselections were stale Teller source-mutant assumptions reproduced unchanged on that pristine rh base.
- All directly changed deployable contracts plus transitive StabilityPool compile below EIP-170.
- The complete repository suite is intentionally deferred until this PR is merged into rh; iteration on this draft uses feature-focused tests only.

| Contract | Deployed bytes | Headroom |
| --- | ---: | ---: |
| MissionControl | 15,844 | 8,732 |
| SwitchboardAlpha | 23,434 | 1,142 |
| SwitchboardBravo | 22,809 | 1,767 |
| SwitchboardCharlie | 23,485 | 1,091 |
| Teller | 24,422 | 154 |
| BondRoom | 10,745 | 13,831 |
| Lootbox | 22,123 | 2,453 |
| HumanResources | 12,296 | 12,280 |
| CreditEngine | 24,314 | 262 |
| CreditRedeem | 8,161 | 16,415 |
| StabilityPool | 24,374 | 202 |

No migration or activation work is included; that remains a separate workflow.
