### PR TITLE
RH: restrict RipeGov lock-deposit and lock mutation to Teller (RH-CHANGE-01 DV-01/02/03)

### DIFF
--- a/config/contract-artifact-expectations.json
+++ b/config/contract-artifact-expectations.json
@@ -1131,17 +1131,17 @@
         "committed_path": "scripts/abis/RipeGov.json"
       },
       "artifacts": {
-        "creation_executable_prefix_sha256": "3d2bdd15197869f3d5b7b2af41365a1842d4f06540f5972b3895daad29a9aeb9",
-        "creation_executable_prefix_size": 24610,
-        "creation_metadata_sha256": "34c804b97a591c1cadf484f35dcd899b0302621022fe3a65afbee4e4b64ae8f3",
+        "creation_executable_prefix_sha256": "c4455879fbbc13d6354bbffcfb133dd4524730c2649ab70b559a9636c35bfa0c",
+        "creation_executable_prefix_size": 24601,
+        "creation_metadata_sha256": "5aae5c858c91aa4be505288b31d80e4bef742373c844c70741645114739c916d",
         "creation_metadata_size": 56,
-        "creation_sha256": "8370a35fadbe61feb087067e4b6b143deca35badab919751daa192cf0844921f",
-        "creation_size": 24666,
-        "deployed_eip170_headroom": 45,
-        "deployed_runtime_size": 24531,
-        "eip170_headroom": 77,
-        "runtime_template_sha256": "c747d2c442df21ac6be5a80d6ed03d8049c9cbf2d46d24c7106a4a119f2470fb",
-        "runtime_template_size": 24499
+        "creation_sha256": "1310c7001227a46b73fe526a98546987472d9bff913ab770506cf005bf0214ca",
+        "creation_size": 24657,
+        "deployed_eip170_headroom": 54,
+        "deployed_runtime_size": 24522,
+        "eip170_headroom": 86,
+        "runtime_template_sha256": "66379801249c95f2db2fb2aaf280f4778783b6de5197c09deb472bc8abb0c774",
+        "runtime_template_size": 24490
       },
       "code_layout": {
         "addys": {
@@ -1179,9 +1179,9 @@
         "canonical_sha256": "23c4d5f465b9913b6d55f4ad7d6d60b301ef3a51a66af988eba984fbe00b4b46",
         "count": 64
       },
-      "source_git_blob": "2cc26d104a86a181b6a53966778c25daf50507ec",
+      "source_git_blob": "8aefda69d9fed79ebacc1915e11e0a29105009fc",
       "source_path": "contracts/vaults/RipeGov.vy",
-      "source_sha256": "c5675bebebac5fc556e11284dca83f635eb8d6df40a6a14346138f52402109fb",
+      "source_sha256": "99780b9633dbc09a0824e9fe03e0e479ce82a24dce6d10d93050e8a398fc9046",
       "storage_layout": {
         "govPointAccrualDisabledBlock": {
           "n_slots": 1,
@@ -1268,7 +1268,7 @@
           "type": "nonreentrant lock"
         }
       },
-      "transitive_compiler_input_integrity": "a1ae63a65d6d9d541521589b9f36992bac98b2c910be31fbd66d58f76fd20707"
+      "transitive_compiler_input_integrity": "ffa3195c86c434635da5e1485b2e55aa3544a029d002c2cb42246a747f713938"
     },
     "SimpleErc20": {
       "abi": {

--- a/contracts/vaults/RipeGov.vy
+++ b/contracts/vaults/RipeGov.vy
@@ -187,7 +187,7 @@ def depositTokensWithLockDuration(
     _lockDuration: uint256,
     _a: addys.Addys = empty(addys.Addys),
 ) -> uint256:
-    assert addys._isValidRipeAddr(msg.sender) # dev: no perms
+    assert msg.sender == addys._getTellerAddr() # dev: only Teller allowed
     return self._depositTokensInRipeGovVault(_user, _asset, _amount, _lockDuration, _a)
 
 
@@ -762,7 +762,7 @@ def adjustLock(
     _newLockDuration: uint256,
     _a: addys.Addys = empty(addys.Addys),
 ):
-    assert addys._isValidRipeAddr(msg.sender) # dev: no perms
+    assert msg.sender == addys._getTellerAddr() # dev: only Teller allowed
     a: addys.Addys = addys._getAddys(_a)
 
     # do a full update first
@@ -794,7 +794,7 @@ def releaseLock(
     _asset: address,
     _a: addys.Addys = empty(addys.Addys),
 ):
-    assert addys._isValidRipeAddr(msg.sender) # dev: no perms
+    assert msg.sender == addys._getTellerAddr() # dev: only Teller allowed
     a: addys.Addys = addys._getAddys(_a)
 
     # they are probably wanting to exit early because of bad debt, crisis of confidence

--- a/tests/core/teller/test_teller_action_block.py
+++ b/tests/core/teller/test_teller_action_block.py
@@ -680,6 +680,7 @@ def test_surviving_batch_routes_are_callable_runtime_controls(
     signature,
     types,
     teller_route_matrix_env,
+    teller,
 ):
     """Bind the same raw selector derivation to live surviving batch routes."""
 

--- a/tests/core/teller/test_teller_deposit.py
+++ b/tests/core/teller/test_teller_deposit.py
@@ -3100,7 +3100,7 @@ def test_predeployment_valid_ripe_lock_route_preserves_direct_clamp_boundary(
         token,
         requested,
         500,
-        sender=switchboard_alpha.address,
+        sender=teller.address,
     )
 
     assert returned == available

--- a/tests/vaults/modules/test_stab_vault_claims.py
+++ b/tests/vaults/modules/test_stab_vault_claims.py
@@ -4245,7 +4245,7 @@ def test_stab_reward_lock_never_shortens_a_later_existing_unlock(
     existing = 1_000 * EIGHTEEN_DECIMALS
     ripe_token.transfer(ripe_gov_vault, existing, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, existing, 1_100, sender=switchboard_alpha.address
+        bob, ripe_token, existing, 1_100, sender=teller.address
     )
     prior_unlock = ripe_gov_vault.userGovData(bob, ripe_token).unlock
     assert prior_unlock == boa.env.evm.patch.block_number + 1_100

--- a/tests/vaults/test_ripe_gov_controls_and_migration.py
+++ b/tests/vaults/test_ripe_gov_controls_and_migration.py
@@ -51,6 +51,8 @@ def target_ripe_gov_vault(ripe_hq, vault_book, governance):
 
 
 def _direct_deposit(vault, token, funder, user, amount, teller, lock_duration=0, switchboard=None):
+    # `switchboard` is retained only so existing call sites keep working; RipeGov
+    # now accepts these deposits from Teller alone.
     token.transfer(vault, amount, sender=funder)
     if lock_duration == 0:
         return vault.depositTokensInVault(user, token, amount, sender=teller.address)
@@ -59,7 +61,7 @@ def _direct_deposit(vault, token, funder, user, amount, teller, lock_duration=0,
         token,
         amount,
         lock_duration,
-        sender=switchboard.address,
+        sender=teller.address,
     )
 
 
@@ -812,12 +814,12 @@ def test_disabled_points_leave_lock_adjustment_and_release_operational(
     before = _save_points(ripe_gov_vault, bob, ripe_token, switchboard_alpha)
     ripe_gov_vault.disableGovPointAccrualForUser(bob, sender=switchboard_echo.address)
 
-    ripe_gov_vault.adjustLock(bob, ripe_token, 800, sender=switchboard_alpha.address)
+    ripe_gov_vault.adjustLock(bob, ripe_token, 800, sender=teller.address)
     adjusted = ripe_gov_vault.userGovData(bob, ripe_token)
     assert adjusted.govPoints == before.govPoints
     assert adjusted.unlock > before.unlock
 
-    ripe_gov_vault.releaseLock(bob, ripe_token, sender=switchboard_alpha.address)
+    ripe_gov_vault.releaseLock(bob, ripe_token, sender=teller.address)
     released = ripe_gov_vault.userGovData(bob, ripe_token)
     assert released.govPoints == before.govPoints
     assert released.unlock == 0
@@ -2182,7 +2184,7 @@ def test_migrated_source_position_is_permanently_tombstoned(
             ripe_token,
             1,
             100,
-            sender=switchboard_alpha.address,
+            sender=teller.address,
         )
     alice_balance = ripe_gov_vault.getTotalAmountForUser(alice, ripe_token)
     with boa.reverts("recipient position migrated"):
@@ -2858,7 +2860,10 @@ def test_unregistered_gov_privileged_call_is_rejected_and_fully_atomic(
     caller = unregistered_callers[caller_name]
     before = _gov_state_snapshot(ripe_gov_vault, ripe_token, [bob, alice])
 
-    with boa.reverts("no perms"):
+    expected = (
+        "no perms" if method == "updateUserGovPoints" else "only Teller allowed"
+    )
+    with boa.reverts(expected):
         if method == "depositTokensWithLockDuration":
             ripe_gov_vault.depositTokensWithLockDuration(
                 alice, ripe_token, gov_position, 1_000, sender=caller
@@ -2878,52 +2883,9 @@ def test_unregistered_gov_privileged_call_is_rejected_and_fully_atomic(
 # --------------------------------------------------------------------------
 
 
-def test_registered_non_teller_mints_gov_shares_from_existing_custody(
-    ripe_gov_vault,
-    ripe_token,
-    bob,
-    alice,
-    switchboard_bravo,
-    gov_position,
-):
-    """DV-01 characterization (SV-1, SV-4).
-
-    depositTokensWithLockDuration accepts any addys._isValidRipeAddr caller and
-    SharesVault mints against the vault's *current* token balance rather than a
-    receipt proven in this transaction. A registered non-Teller contract can
-    therefore mint shares for an arbitrary beneficiary against custody already
-    attributed to another user, while moving no tokens at all.
-    """
-    custody_before = ripe_token.balanceOf(ripe_gov_vault.address)
-    bob_shares_before = ripe_gov_vault.userBalances(bob, ripe_token)
-    assert ripe_gov_vault.getTotalAmountForUser(bob, ripe_token) == gov_position
-    assert ripe_gov_vault.userBalances(alice, ripe_token) == 0
-
-    # The attacker sends no tokens to the vault.
-    minted = ripe_gov_vault.depositTokensWithLockDuration(
-        alice, ripe_token, MAX_UINT256, 1_000, sender=switchboard_bravo.address
-    )
-
-    assert minted == gov_position
-    assert ripe_token.balanceOf(ripe_gov_vault.address) == custody_before
-
-    alice_shares = ripe_gov_vault.userBalances(alice, ripe_token)
-    assert alice_shares > bob_shares_before * 10**19  # near-total dilution
-    assert ripe_gov_vault.getTotalAmountForUser(alice, ripe_token) >= gov_position - 1
-    assert ripe_gov_vault.getTotalAmountForUser(bob, ripe_token) == 0
-
-    # Alice also receives an attacker-chosen lock she never asked for.
-    assert ripe_gov_vault.userGovData(alice, ripe_token).unlock == (
-        boa.env.evm.patch.block_number + 1_000
-    )
 
 
 @pytest.mark.parametrize("caller_name", REGISTERED_NON_TELLER_CALLERS)
-@pytest.mark.xfail(
-    strict=True,
-    reason="DV-01: RipeGov.depositTokensWithLockDuration still uses the broad "
-    "addys._isValidRipeAddr predicate; least-privilege fix is gated on RH-CHANGE-01",
-)
 def test_registered_non_teller_cannot_mint_gov_shares_from_existing_custody(
     caller_name,
     ripe_gov_vault,
@@ -2949,29 +2911,9 @@ def test_registered_non_teller_cannot_mint_gov_shares_from_existing_custody(
 # --------------------------------------------------------------------------
 
 
-def test_registered_non_teller_adjusts_another_users_lock(
-    ripe_gov_vault, ripe_token, bob, stability_pool, gov_position
-):
-    """DV-02 characterization (SV-4, RG-4).
-
-    An unrelated registered contract -- here the StabilityPool, which has no
-    production reason to touch governance locks -- can extend Bob's lock.
-    """
-    unlock_before = ripe_gov_vault.userGovData(bob, ripe_token).unlock
-
-    ripe_gov_vault.adjustLock(bob, ripe_token, 1_000, sender=stability_pool.address)
-
-    unlock_after = ripe_gov_vault.userGovData(bob, ripe_token).unlock
-    assert unlock_after == boa.env.evm.patch.block_number + 1_000
-    assert unlock_after > unlock_before
 
 
 @pytest.mark.parametrize("caller_name", REGISTERED_NON_TELLER_CALLERS)
-@pytest.mark.xfail(
-    strict=True,
-    reason="DV-02: RipeGov.adjustLock still uses the broad addys._isValidRipeAddr "
-    "predicate; least-privilege fix is gated on RH-CHANGE-01",
-)
 def test_registered_non_teller_cannot_adjust_another_users_lock(
     caller_name,
     ripe_gov_vault,
@@ -2994,38 +2936,9 @@ def test_registered_non_teller_cannot_adjust_another_users_lock(
 # --------------------------------------------------------------------------
 
 
-def test_registered_non_teller_releases_another_users_lock_and_burns_exit_fee(
-    ripe_gov_vault, ripe_token, bob, stability_pool, locked_gov_position
-):
-    """DV-03 characterization (SV-4, RG-4).
-
-    releaseLock charges the configured exit fee out of the victim's shares and
-    clears the lock. An unrelated registered contract can force this on a user
-    who never asked to exit early.
-    """
-    shares_before = ripe_gov_vault.userBalances(bob, ripe_token)
-    unlock_before = ripe_gov_vault.userGovData(bob, ripe_token).unlock
-    assert unlock_before > boa.env.evm.patch.block_number
-
-    ripe_gov_vault.releaseLock(bob, ripe_token, sender=stability_pool.address)
-    logs = filter_logs(ripe_gov_vault, "LockReleased")
-
-    # LOCK_TERMS exit fee is 10.00%.
-    expected_removed = shares_before * LOCK_TERMS[4] // 100_00
-    assert ripe_gov_vault.userBalances(bob, ripe_token) == shares_before - expected_removed
-    assert ripe_gov_vault.userGovData(bob, ripe_token).unlock == 0
-
-    assert len(logs) == 1
-    assert logs[0].user == bob
-    assert logs[0].exitFee == LOCK_TERMS[4]
 
 
 @pytest.mark.parametrize("caller_name", REGISTERED_NON_TELLER_CALLERS)
-@pytest.mark.xfail(
-    strict=True,
-    reason="DV-03: RipeGov.releaseLock still uses the broad addys._isValidRipeAddr "
-    "predicate; least-privilege fix is gated on RH-CHANGE-01",
-)
 def test_registered_non_teller_cannot_release_another_users_lock(
     caller_name,
     ripe_gov_vault,
@@ -3495,7 +3408,7 @@ def _invoke_gov_mutation(
     elif method == "depositTokensWithLockDuration":
         ripe_token.transfer(vault, EIGHTEEN_DECIMALS, sender=whale)
         vault.depositTokensWithLockDuration(
-            bob, ripe_token, EIGHTEEN_DECIMALS, 500, sender=switchboard_bravo.address
+            bob, ripe_token, EIGHTEEN_DECIMALS, 500, sender=teller.address
         )
     elif method == "withdrawTokensFromVault":
         vault.withdrawTokensFromVault(bob, ripe_token, amount, bob, sender=teller.address)

--- a/tests/vaults/test_ripe_gov_vault.py
+++ b/tests/vaults/test_ripe_gov_vault.py
@@ -70,7 +70,8 @@ def test_ripe_gov_vault_initial_deposit_no_lock(
 
 
 def test_ripe_gov_vault_deposit_with_lock_duration(
-    ripe_gov_vault, ripe_token, whale, bob, switchboard_alpha, setupRipeGovVaultConfig
+    ripe_gov_vault, ripe_token, whale, bob, switchboard_alpha, setupRipeGovVaultConfig,
+    teller,
 ):
     """Test deposit with specific lock duration"""
     setupRipeGovVaultConfig()
@@ -82,7 +83,7 @@ def test_ripe_gov_vault_deposit_with_lock_duration(
     
     # Deposit with lock duration
     deposited = ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, lock_duration, sender=switchboard_alpha.address
+        bob, ripe_token, deposit_amount, lock_duration, sender=teller.address
     )
     assert deposited == deposit_amount
     
@@ -110,7 +111,7 @@ def test_ripe_gov_vault_multiple_deposits_weighted_lock(
     # Second deposit with longer lock
     ripe_token.transfer(ripe_gov_vault, second_deposit, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, second_deposit, 800, sender=switchboard_alpha.address
+        bob, ripe_token, second_deposit, 800, sender=teller.address
     )
     
     second_unlock = ripe_gov_vault.userGovData(bob, ripe_token).unlock
@@ -131,7 +132,7 @@ def test_ripe_gov_vault_deposit_validation(
         ripe_gov_vault.depositTokensInVault(bob, ripe_token, 100, sender=alice)
     
     # Test unauthorized caller for depositWithLockDuration
-    with boa.reverts("no perms"):
+    with boa.reverts("only Teller allowed"):
         ripe_gov_vault.depositTokensWithLockDuration(bob, ripe_token, 100, 500, sender=alice)
 
 
@@ -182,7 +183,7 @@ def test_ripe_gov_vault_withdrawal_before_unlock_fails(
     # Deposit with lock
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 100, sender=switchboard_alpha.address
+        bob, ripe_token, deposit_amount, 100, sender=teller.address
     )
     
     # Should revert with "not reached unlock" - trying to withdraw before unlock time
@@ -301,19 +302,20 @@ def test_ripe_gov_vault_adjust_lock_permission_check(
     setupRipeGovVaultConfig()
 
     # Should revert with "no perms" - only RipeHq addresses can call adjustLock
-    with boa.reverts("no perms"):
+    with boa.reverts("only Teller allowed"):
         ripe_gov_vault.adjustLock(bob, ripe_token, 500, sender=alice)
 
 
 def test_ripe_gov_vault_adjust_lock_no_position_fails(
-    ripe_gov_vault, ripe_token, bob, switchboard_alpha, setupRipeGovVaultConfig
+    ripe_gov_vault, ripe_token, bob, switchboard_alpha, setupRipeGovVaultConfig,
+    teller,
 ):
     """Test adjusting lock with no position fails"""
     setupRipeGovVaultConfig()
 
     # Should revert with "no lock terms" - no lock terms configured yet (first assertion)
     with boa.reverts("no lock terms"):
-        ripe_gov_vault.adjustLock(bob, ripe_token, 500, sender=switchboard_alpha.address)
+        ripe_gov_vault.adjustLock(bob, ripe_token, 500, sender=teller.address)
 
 
 def test_ripe_gov_vault_adjust_lock_with_terms_but_no_position_fails(
@@ -337,7 +339,7 @@ def test_ripe_gov_vault_adjust_lock_with_terms_but_no_position_fails(
     
     # Should revert with "no position" - user has lock terms configured but no shares
     with boa.reverts("no position"):
-        ripe_gov_vault.adjustLock(bob, ripe_token, 500, sender=switchboard_alpha.address)
+        ripe_gov_vault.adjustLock(bob, ripe_token, 500, sender=teller.address)
 
 
 def test_ripe_gov_vault_adjust_lock_extend_duration(
@@ -359,7 +361,7 @@ def test_ripe_gov_vault_adjust_lock_extend_duration(
     assert initial_unlock == current_block + 100  # Should be minimum lock duration
     
     # Adjust lock to extend duration to 800 blocks
-    ripe_gov_vault.adjustLock(bob, ripe_token, 800, sender=switchboard_alpha.address)
+    ripe_gov_vault.adjustLock(bob, ripe_token, 800, sender=teller.address)
     
     # Verify unlock time was updated
     userData_after = ripe_gov_vault.userGovData(bob, ripe_token)
@@ -382,7 +384,7 @@ def test_ripe_gov_vault_adjust_lock_cannot_reduce_duration(
     # Deposit tokens with long lock duration
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 800, sender=switchboard_alpha.address  # 800 block lock
+        bob, ripe_token, deposit_amount, 800, sender=teller.address  # 800 block lock
     )
     
     # Verify initial unlock time
@@ -395,18 +397,19 @@ def test_ripe_gov_vault_adjust_lock_cannot_reduce_duration(
     # Even though we're asking for 500 blocks, the new unlock would be current_block + 500
     # which is less than the existing unlock time
     with boa.reverts("new lock cannot be earlier"):
-        ripe_gov_vault.adjustLock(bob, ripe_token, 500, sender=switchboard_alpha.address)
+        ripe_gov_vault.adjustLock(bob, ripe_token, 500, sender=teller.address)
 
 
 def test_ripe_gov_vault_release_lock_no_position_fails(
-    ripe_gov_vault, ripe_token, bob, switchboard_alpha, setupRipeGovVaultConfig
+    ripe_gov_vault, ripe_token, bob, switchboard_alpha, setupRipeGovVaultConfig,
+    teller,
 ):
     """Test releasing lock with no position fails"""
     setupRipeGovVaultConfig()
 
     # Should revert with "no release needed" - no unlock time set (first assertion)
     with boa.reverts("no release needed"):
-        ripe_gov_vault.releaseLock(bob, ripe_token, sender=switchboard_alpha.address)
+        ripe_gov_vault.releaseLock(bob, ripe_token, sender=teller.address)
 
 
 def test_ripe_gov_vault_release_lock_permission_check(
@@ -416,7 +419,7 @@ def test_ripe_gov_vault_release_lock_permission_check(
     setupRipeGovVaultConfig()
 
     # Should revert with "no perms" - only RipeHq addresses can call releaseLock
-    with boa.reverts("no perms"):
+    with boa.reverts("only Teller allowed"):
         ripe_gov_vault.releaseLock(bob, ripe_token, sender=alice)
 
 
@@ -476,7 +479,7 @@ def test_ripe_gov_vault_lock_bonus_points(
     # Alice deposits with long lock duration (should get bonus)
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        alice, ripe_token, deposit_amount, 900, sender=switchboard_alpha.address  # Near max lock
+        alice, ripe_token, deposit_amount, 900, sender=teller.address  # Near max lock
     )
     
     # Advance time equally for both
@@ -679,7 +682,8 @@ def test_ripe_gov_vault_configuration_updates_after_deposit(
 
 
 def test_ripe_gov_vault_lock_terms_enforcement(
-    ripe_gov_vault, ripe_token, whale, bob, switchboard_alpha, setupRipeGovVaultConfig
+    ripe_gov_vault, ripe_token, whale, bob, switchboard_alpha, setupRipeGovVaultConfig,
+    teller,
 ):
     """Test that lock terms are enforced (min/max durations)"""
     setupRipeGovVaultConfig()
@@ -689,7 +693,7 @@ def test_ripe_gov_vault_lock_terms_enforcement(
     # Test with below minimum lock duration (should be increased to minimum)
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 50, sender=switchboard_alpha.address  # Below min (100)
+        bob, ripe_token, deposit_amount, 50, sender=teller.address  # Below min (100)
     )
     
     userData = ripe_gov_vault.userGovData(bob, ripe_token)
@@ -699,7 +703,7 @@ def test_ripe_gov_vault_lock_terms_enforcement(
     # Test with above maximum lock duration (should be capped to maximum)
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 1500, sender=switchboard_alpha.address  # Above max (1000)
+        bob, ripe_token, deposit_amount, 1500, sender=teller.address  # Above max (1000)
     )
     
     # The unlock should be a weighted average between previous min lock (100) and max lock (1000)
@@ -725,7 +729,7 @@ def test_ripe_gov_vault_release_lock_when_cannot_exit(
     
     # Should revert with "cannot exit" - exit is disabled in config
     with boa.reverts("cannot exit"):
-        ripe_gov_vault.releaseLock(bob, ripe_token, sender=switchboard_alpha.address)
+        ripe_gov_vault.releaseLock(bob, ripe_token, sender=teller.address)
 
 
 def test_ripe_gov_vault_release_lock_when_no_unlock_needed(
@@ -748,11 +752,12 @@ def test_ripe_gov_vault_release_lock_when_no_unlock_needed(
     
     # Should revert with "no release needed" - already past unlock time
     with boa.reverts("no release needed"):
-        ripe_gov_vault.releaseLock(bob, ripe_token, sender=switchboard_alpha.address)
+        ripe_gov_vault.releaseLock(bob, ripe_token, sender=teller.address)
 
 
 def test_ripe_gov_vault_release_lock_successful_with_exit_fee(
-    ripe_gov_vault, ripe_token, whale, bob, switchboard_alpha, _test, setupRipeGovVaultConfig
+    ripe_gov_vault, ripe_token, whale, bob, switchboard_alpha, _test, setupRipeGovVaultConfig,
+    teller,
 ):
     """Test that release lock works successfully and charges exit fee"""
     # Setup with exit enabled and 10% exit fee
@@ -763,7 +768,7 @@ def test_ripe_gov_vault_release_lock_successful_with_exit_fee(
     # Deposit tokens with lock duration
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 500, sender=switchboard_alpha.address  # 500 block lock
+        bob, ripe_token, deposit_amount, 500, sender=teller.address  # 500 block lock
     )
     
     # Verify initial state - should be locked
@@ -778,7 +783,7 @@ def test_ripe_gov_vault_release_lock_successful_with_exit_fee(
     assert shares_before > 0  # Should have shares
     
     # Release lock early (should charge 10% exit fee)
-    ripe_gov_vault.releaseLock(bob, ripe_token, sender=switchboard_alpha.address)
+    ripe_gov_vault.releaseLock(bob, ripe_token, sender=teller.address)
     
     # Verify state after release
     userData_after = ripe_gov_vault.userGovData(bob, ripe_token)
@@ -803,7 +808,8 @@ def test_ripe_gov_vault_release_lock_successful_with_exit_fee(
 
 
 def test_ripe_gov_vault_release_lock_state_changes(
-    ripe_gov_vault, ripe_token, whale, bob, switchboard_alpha, _test, setupRipeGovVaultConfig
+    ripe_gov_vault, ripe_token, whale, bob, switchboard_alpha, _test, setupRipeGovVaultConfig,
+    teller,
 ):
     """Test that release lock properly updates all state variables"""
     # Setup with exit enabled and 5% exit fee
@@ -814,7 +820,7 @@ def test_ripe_gov_vault_release_lock_state_changes(
     # Deposit tokens with lock duration
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 600, sender=switchboard_alpha.address  # 600 block lock
+        bob, ripe_token, deposit_amount, 600, sender=teller.address  # 600 block lock
     )
     
     # Advance some time to accumulate governance points while locked
@@ -831,7 +837,7 @@ def test_ripe_gov_vault_release_lock_state_changes(
     assert shares_before > 0  # Has shares
     
     # Release lock
-    ripe_gov_vault.releaseLock(bob, ripe_token, sender=switchboard_alpha.address)
+    ripe_gov_vault.releaseLock(bob, ripe_token, sender=teller.address)
     
     # Verify all state changes
     userData_after = ripe_gov_vault.userGovData(bob, ripe_token)
@@ -868,7 +874,7 @@ def test_ripe_gov_vault_complex_points_scenario(
     # Bob deposits with lock
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 800, sender=switchboard_alpha.address
+        bob, ripe_token, deposit_amount, 800, sender=teller.address
     )
     
     # Alice deposits with minimum lock
@@ -971,7 +977,8 @@ def test_ripe_gov_vault_zero_asset_weight_no_points(
 
 
 def test_ripe_gov_vault_max_lock_boost_comparison(
-    ripe_gov_vault, ripe_token, whale, bob, charlie, switchboard_alpha, setupRipeGovVaultConfig
+    ripe_gov_vault, ripe_token, whale, bob, charlie, switchboard_alpha, setupRipeGovVaultConfig,
+    teller,
 ):
     """Test that higher max lock boost results in more bonus points"""
     deposit_amount = 100 * EIGHTEEN_DECIMALS
@@ -981,7 +988,7 @@ def test_ripe_gov_vault_max_lock_boost_comparison(
 
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 1000, sender=switchboard_alpha.address  # Max lock
+        bob, ripe_token, deposit_amount, 1000, sender=teller.address  # Max lock
     )
     
     # Advance time and update points
@@ -995,7 +1002,7 @@ def test_ripe_gov_vault_max_lock_boost_comparison(
 
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        charlie, ripe_token, deposit_amount, 1000, sender=switchboard_alpha.address  # Max lock
+        charlie, ripe_token, deposit_amount, 1000, sender=teller.address  # Max lock
     )
     
     # Advance time and update points
@@ -1011,7 +1018,8 @@ def test_ripe_gov_vault_max_lock_boost_comparison(
 
 
 def test_ripe_gov_vault_short_lock_range_enforcement(
-    ripe_gov_vault, ripe_token, whale, bob, switchboard_alpha, setupRipeGovVaultConfig
+    ripe_gov_vault, ripe_token, whale, bob, switchboard_alpha, setupRipeGovVaultConfig,
+    teller,
 ):
     """Test vault with very short lock duration range"""
     # Setup with narrow lock range
@@ -1022,7 +1030,7 @@ def test_ripe_gov_vault_short_lock_range_enforcement(
     # Test that lock durations are properly clamped to range
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 200, sender=switchboard_alpha.address  # Should be clamped to 110
+        bob, ripe_token, deposit_amount, 200, sender=teller.address  # Should be clamped to 110
     )
     
     userData = ripe_gov_vault.userGovData(bob, ripe_token)
@@ -1636,7 +1644,7 @@ def test_ripe_gov_vault_zero_exit_fee_blocks_release_lock_defensive(
     # Deposit tokens with lock duration
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 500, sender=switchboard_alpha.address
+        bob, ripe_token, deposit_amount, 500, sender=teller.address
     )
     
     # Verify user is locked
@@ -1648,7 +1656,7 @@ def test_ripe_gov_vault_zero_exit_fee_blocks_release_lock_defensive(
     
     # Try to release lock - vault should defensively reject this
     with boa.reverts():  # Should revert with "no exit fee" - vault's defensive validation
-        ripe_gov_vault.releaseLock(bob, ripe_token, sender=switchboard_alpha.address)
+        ripe_gov_vault.releaseLock(bob, ripe_token, sender=teller.address)
     
     # This demonstrates the vault's defensive programming:
     # Even if somehow an invalid configuration exists, the vault protects itself
@@ -2139,7 +2147,8 @@ def test_ripe_gov_vault_withdrawal_works_when_bad_debt_freeze_disabled(
 
 
 def test_ripe_gov_vault_release_lock_blocked_when_bad_debt_and_freeze_enabled(
-    ripe_gov_vault, ripe_token, whale, bob, ledger, switchboard_alpha, setupRipeGovVaultConfig
+    ripe_gov_vault, ripe_token, whale, bob, ledger, switchboard_alpha, setupRipeGovVaultConfig,
+    teller,
 ):
     """Test that releaseLock() is blocked when bad debt exists and shouldFreezeWhenBadDebt=True to save users money"""
     # Setup with exit enabled and exit fee, and freeze enabled
@@ -2156,7 +2165,7 @@ def test_ripe_gov_vault_release_lock_blocked_when_bad_debt_and_freeze_enabled(
     # Deposit tokens with lock duration
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 500, sender=switchboard_alpha.address
+        bob, ripe_token, deposit_amount, 500, sender=teller.address
     )
     
     # Verify user is locked and can normally release lock without bad debt
@@ -2180,7 +2189,7 @@ def test_ripe_gov_vault_release_lock_blocked_when_bad_debt_and_freeze_enabled(
     
     # Now releaseLock should fail to save user money since withdrawals would be frozen anyway
     with boa.reverts("saving user money"):
-        ripe_gov_vault.releaseLock(bob, ripe_token, sender=switchboard_alpha.address)
+        ripe_gov_vault.releaseLock(bob, ripe_token, sender=teller.address)
     
     # User's position should remain unchanged (not charged exit fee)
     userData_after = ripe_gov_vault.userGovData(bob, ripe_token)
@@ -2189,7 +2198,8 @@ def test_ripe_gov_vault_release_lock_blocked_when_bad_debt_and_freeze_enabled(
 
 
 def test_ripe_gov_vault_release_lock_works_when_bad_debt_but_freeze_disabled(
-    ripe_gov_vault, ripe_token, whale, bob, ledger, switchboard_alpha, setupRipeGovVaultConfig
+    ripe_gov_vault, ripe_token, whale, bob, ledger, switchboard_alpha, setupRipeGovVaultConfig,
+    teller,
 ):
     """Test that releaseLock() works when bad debt exists but shouldFreezeWhenBadDebt=False"""
     # Setup with exit enabled and exit fee, but freeze disabled
@@ -2206,7 +2216,7 @@ def test_ripe_gov_vault_release_lock_works_when_bad_debt_but_freeze_disabled(
     # Deposit tokens with lock duration
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 400, sender=switchboard_alpha.address
+        bob, ripe_token, deposit_amount, 400, sender=teller.address
     )
     
     # Verify user is locked
@@ -2225,7 +2235,7 @@ def test_ripe_gov_vault_release_lock_works_when_bad_debt_but_freeze_disabled(
     assert ledger.badDebt() == bad_debt_amount
     
     # Release lock should work because freeze is disabled (even with bad debt)
-    ripe_gov_vault.releaseLock(bob, ripe_token, sender=switchboard_alpha.address)
+    ripe_gov_vault.releaseLock(bob, ripe_token, sender=teller.address)
     
     # Verify lock was released and exit fee was charged
     userData_after = ripe_gov_vault.userGovData(bob, ripe_token)
@@ -2242,7 +2252,8 @@ def test_ripe_gov_vault_release_lock_works_when_bad_debt_but_freeze_disabled(
 
 
 def test_ripe_gov_vault_release_lock_works_when_no_bad_debt_regardless_of_freeze_setting(
-    ripe_gov_vault, ripe_token, whale, bob, ledger, switchboard_alpha, setupRipeGovVaultConfig
+    ripe_gov_vault, ripe_token, whale, bob, ledger, switchboard_alpha, setupRipeGovVaultConfig,
+    teller,
 ):
     """Test that releaseLock() works normally when there's no bad debt, regardless of shouldFreezeWhenBadDebt setting"""
     # Test with freeze enabled first
@@ -2259,7 +2270,7 @@ def test_ripe_gov_vault_release_lock_works_when_no_bad_debt_regardless_of_freeze
     # Deposit tokens with lock duration
     ripe_token.transfer(ripe_gov_vault, deposit_amount, sender=whale)
     ripe_gov_vault.depositTokensWithLockDuration(
-        bob, ripe_token, deposit_amount, 600, sender=switchboard_alpha.address
+        bob, ripe_token, deposit_amount, 600, sender=teller.address
     )
     
     # Verify user is locked
@@ -2272,7 +2283,7 @@ def test_ripe_gov_vault_release_lock_works_when_no_bad_debt_regardless_of_freeze
     assert ledger.badDebt() == 0
     
     # Release lock should work normally since there's no bad debt
-    ripe_gov_vault.releaseLock(bob, ripe_token, sender=switchboard_alpha.address)
+    ripe_gov_vault.releaseLock(bob, ripe_token, sender=teller.address)
     
     # Verify lock was released and exit fee was charged
     userData_after = ripe_gov_vault.userGovData(bob, ripe_token)


### PR DESCRIPTION
## Summary

RH-CHANGE-01 approved row **DV-01/02/03**: restrict RipeGov's three privileged functions to Teller.

Production diff is **three lines** in `contracts/vaults/RipeGov.vy`.

## The problem

`depositTokensWithLockDuration`, `adjustLock` and `releaseLock` were guarded by `assert addys._isValidRipeAddr(msg.sender)`. Reading `Addys.vy`, that admits:

- every RipeHq core department (Teller, AuctionHouse, CreditEngine, HumanResources, Lootbox, BondRoom, Deleverage, …)
- **every VaultBook-registered vault** (StabilityPool, SimpleErc20, RebaseErc20, RipeGov itself)
- **every switchboard** (Alpha–Echo)

Twenty-plus contracts. A fresh caller inventory found **Teller is the only production caller of all three** — `Teller.vy:338`, `:826`, `:843`.

The deposit path is the sharp edge. `SharesVault._depositTokensInVault` mints against the vault's *current token balance*, not a receipt proven in the same transaction. So a registered contract could call it with `_amount = max_uint256`, naming any beneficiary, **sending no tokens**:

- Bob deposits 100 RIPE normally.
- A registered contract mints to Alice. Alice's shares exceed Bob's by >10¹⁹×; Alice can withdraw ~100 RIPE; **Bob's withdrawable balance is zero**. Vault token balance unchanged.

`adjustLock` and `releaseLock` let any registered address extend or force-release another user's lock — and force-release burns the 10% exit fee out of their position.

Not EOA-reachable: it needs a registered contract compromised or forwarding a call. The decisive factor was that **the surface grew silently** — every newly registered vault or department inherited the capability with no opt-in.

`updateUserGovPoints` deliberately keeps the broad predicate; it only recomputes points and is outside the approved row.

## Size

| | Template | Deployed | EIP-170 headroom |
|---|---:|---:|---:|
| before | 24,499 | 24,531 | 45 |
| after | **24,490** | **24,522** | **54** |

The only candidate mitigation that makes RipeGov *smaller*. No ABI, selector, event, or storage-layout change — `config/contract-artifact-expectations.json` is regenerated for the source and bytecode hashes only, verified with `scripts/check_contract_artifacts.py --contract RipeGov` → `CONTRACT_ARTIFACTS_OK`.

RipeGov is already in the pending redeploy (`migrations/robinhood-mainnet/0009_RedeployStaleContracts.py:115`), so this rides that rather than needing its own.

## Tests

38 legitimate call sites rewired from switchboard senders to Teller. Section 6.1 post-remediation transition applied: the three characterizations of the removed behavior are deleted, and the **39 strict-xfail checkpoints are promoted to plain passing regressions**. The unregistered-caller matrix now expects `only Teller allowed` for the three restricted methods and `no perms` for `updateUserGovPoints`.

| Lane | Result | vs baseline `6260726` |
|---|---|---|
| 16.1 RipeGov focused | **408 passed, 13 xfailed** | 372→408 passed, 52→13 xfailed |
| 16.2 StabilityPool focused | 233 passed, 8 xfailed | unchanged |
| 16.3 composed | 381 passed, 1 failed, 3 xfailed | same single pre-existing failure |
| 16.4 shared-vault | 591 passed, 1 failed, 21 xfailed | same single pre-existing failure |
| 16.4 fuzz | 4 passed | unchanged |
| migration regression | 86 passed | unchanged |
| bondRoom + config + creditEngine | 6 failed, 817 passed | **identical to baseline** |

The 13 remaining xfails are the un-approved rows (DV-04 same-address transfer, DV-05 contributor lock clamp, DV-06 pause) plus GOV-WEIGHT-01. No XPASS. Every failing node also fails on the clean baseline.

Baseline is pinned at `6260726`; `rh` is moving during an active deployment, so this branch deliberately does not chase the tip.

## Pre-existing issues observed, not touched

- `config/contract-artifact-expectations.json` has **MissionControl source drift on clean `rh`** — `check_contract_artifacts.py` fails there before any change of mine.
- The two known red tests (titanoboa `IntegerT.key_type` trace pollution; stale `test_basic_vault_consumer_inventory`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
