### PR TITLE
test(rh): reconcile the Teller size floor to 200 bytes

### DIFF
--- a/docs/chains/rh/deposit-vault-hardening-wp0-evidence.md
+++ b/docs/chains/rh/deposit-vault-hardening-wp0-evidence.md
@@ -96,11 +96,27 @@ guard and is included in §5.3.
 | **RH-LANE-01** | **RESOLVED by the owner's action.** The migration lane went first and is integrated as `24de5e6`. This plan is rebound onto it. No second live lane is modifying Teller. |
 | SP-PRICE-01 | Option A by default. Characterized; no production change needed for A. But see DV-14: option A's liveness claim does not hold for a reverting price source. |
 | GOV-WEIGHT-01 | **UNRESOLVED.** No autonomous default. |
-| RG-SIZE-01 | **UNRESOLVED.** §6 E-2 now shows Option A is feasible at a stated cost. |
+| RG-SIZE-01 | **RESOLVED by the owner 2026-08-08:** the 200-byte floor governs. See the disposition below. §6 E-2 shows Option A is feasible at a stated cost. |
 | RH-CHANGE-01 | **UNRESOLVED.** No row approved; no production source edited. |
 
-**Stop condition encountered:** GOV-WEIGHT-01, RG-SIZE-01 and RH-CHANGE-01
-remain unresolved, so no production-contract edit was made.
+**Stop condition encountered at WP0:** GOV-WEIGHT-01, RG-SIZE-01 and
+RH-CHANGE-01 were all unresolved *at the time this evidence was recorded*, so no
+production-contract edit was made in WP0. Dispositions reached after that point
+are recorded below rather than by rewriting the WP0 narrative.
+
+#### RG-SIZE-01 disposition — owner, 2026-08-08
+
+**The hardening plan's 200-byte floor governs.** `MIN_TELLER_MARGIN` in
+`tests/test_vault_pointer_runtime_sizes.py` is lowered from 300 to 200 to match,
+resolving E-8. This is a deliberate relaxation of the floor the vault-migration
+workstream set, made so that the §13 central receipt-window guard (M7c, **+81
+bytes → 237 deployed headroom**) is admissible; at 300 it would be blocked. The
+plan's requirement at §5.3 line 236 — that anything *below* 200 needs a separate
+exact owner waiver — is unchanged and still binding.
+
+Nothing about any deployed contract changed with this decision: Teller's measured
+headroom is 318 bytes, which cleared both floors already. The decision only
+governs what future Teller growth is admissible.
 
 ---
 
@@ -295,11 +311,17 @@ one of §16's lanes; it was run only to check E-3 exposure. The artifact
 *expectations* are current — `scripts/check_contract_artifacts.py` returns
 `CONTRACT_ARTIFACTS_OK`.
 
-**E-8 — NEW: two conflicting Teller size floors now exist.** This plan sets 200
-bytes; the merged migration work set `MIN_TELLER_MARGIN = 300` in
+**E-8 — RESOLVED 2026-08-08: two conflicting Teller size floors existed.** This
+plan sets 200 bytes; the merged migration work set `MIN_TELLER_MARGIN = 300` in
 `tests/test_vault_pointer_runtime_sizes.py`. The §13 central guard (M7c, +81)
 lands at **237 bytes deployed headroom** — passing this plan's floor and failing
-the merged one. The owner must reconcile the two before Work Package 6 proceeds.
+the merged one, which is why the two had to be reconciled before Work Package 6.
+
+**Disposition:** the owner ruled on 2026-08-08 that the 200-byte floor governs,
+and `MIN_TELLER_MARGIN` was lowered from 300 to 200 to match, so a single floor
+now exists in the tree. M7c is therefore admissible on size. Recorded in full
+under the RG-SIZE-01 disposition in §1. No deployed contract changed: Teller's
+measured headroom is 318 bytes, which already cleared both.
 
 ---
 
@@ -341,8 +363,11 @@ pre-existing failures.
 
 ## 8. What was deliberately NOT done, and why
 
-- **All production-contract edits.** RH-CHANGE-01 approves no row;
-  GOV-WEIGHT-01 and RG-SIZE-01 are unresolved. §17 applies.
+- **All production-contract edits.** At the time of WP0, RH-CHANGE-01 approved no
+  row and GOV-WEIGHT-01 and RG-SIZE-01 were both unresolved; §17 applied. *Both
+  of those have since moved — RG-SIZE-01 was resolved by the owner on 2026-08-08
+  (see §1), and a RH-CHANGE-01 row was subsequently approved and merged. This
+  bullet records the WP0 position, not the current one.*
 - **Work Package 3 §10.3 (RipeGov stateful model) and Work Package 7
   (StabilityPool stateful model).** Test-only, but their required invariants are
   the ones currently violated: RG-4 (DV-02/03/05), RG-5 (DV-04), SP-1 (DV-09),

--- a/tests/test_vault_pointer_runtime_sizes.py
+++ b/tests/test_vault_pointer_runtime_sizes.py
@@ -16,14 +16,21 @@ EXPECTED_DEPLOYED_RUNTIME_BYTES = {
 # Teller carries the tightest budget of any contract here: the migration work left
 # 24_576 - 24_258 = 318 bytes of headroom. Treat any further Teller growth as gated.
 #
-# This floor was reconciled by the owner on 2026-08-07. Two floors had been written
-# down independently: 200 bytes in the deposit-vault hardening plan
-# (docs/chains/rh/deposit-vault-smart-contract-hardening-implementation-plan.md
+# This floor was reconciled by the owner on 2026-08-08, resolving RG-SIZE-01. The
+# disposition is recorded in docs/chains/rh/deposit-vault-hardening-wp0-evidence.md
+# (section 1, "RG-SIZE-01 disposition"; it also closes finding E-8 there) -- update
+# both together if it is ever revisited.
+#
+# Two floors had been written down independently: 200 bytes in the deposit-vault
+# hardening plan (docs/chains/rh/deposit-vault-smart-contract-hardening-implementation-plan.md
 # section 5.3, "RG-SIZE-01"), and 300 here, set by the vault-migration work. They
 # disagreed on the same proposed change -- the Section 13 Teller receipt-window
 # guard measures +81 bytes, landing at 237 bytes of headroom, which passes 200 and
 # fails 300. The owner ruled that the hardening plan's 200 governs, so this is
 # lowered to match rather than leaving two contradictory rules in the tree.
+#
+# The plan's other half is unchanged and still binding: anything landing *below*
+# 200 bytes needs a separate exact owner waiver (e.g. M9 at 127 bytes).
 #
 # Lowering it is a deliberate relaxation of a guard the migration workstream set.
 # The 318 bytes currently present still clear the old 300 as well; nothing about

--- a/tests/test_vault_pointer_runtime_sizes.py
+++ b/tests/test_vault_pointer_runtime_sizes.py
@@ -13,10 +13,22 @@ EXPECTED_DEPLOYED_RUNTIME_BYTES = {
     "StabilityPool": 24_371,
 }
 
-# Teller carries the tightest budget of any contract here. The migration work left
-# 24_576 - 24_258 = 318 bytes of headroom, above the 300-byte floor the implementation
-# plan sets but with very little room to spare: treat any further Teller growth as gated.
-MIN_TELLER_MARGIN = 300
+# Teller carries the tightest budget of any contract here: the migration work left
+# 24_576 - 24_258 = 318 bytes of headroom. Treat any further Teller growth as gated.
+#
+# This floor was reconciled by the owner on 2026-08-07. Two floors had been written
+# down independently: 200 bytes in the deposit-vault hardening plan
+# (docs/chains/rh/deposit-vault-smart-contract-hardening-implementation-plan.md
+# section 5.3, "RG-SIZE-01"), and 300 here, set by the vault-migration work. They
+# disagreed on the same proposed change -- the Section 13 Teller receipt-window
+# guard measures +81 bytes, landing at 237 bytes of headroom, which passes 200 and
+# fails 300. The owner ruled that the hardening plan's 200 governs, so this is
+# lowered to match rather than leaving two contradictory rules in the tree.
+#
+# Lowering it is a deliberate relaxation of a guard the migration workstream set.
+# The 318 bytes currently present still clear the old 300 as well; nothing about
+# the deployed contract changed.
+MIN_TELLER_MARGIN = 200
 
 
 def test_pointer_changed_contracts_fit_eip170_deployed_runtime_limit(


### PR DESCRIPTION
## Summary

One-line change: `MIN_TELLER_MARGIN` 300 → 200 in `tests/test_vault_pointer_runtime_sizes.py`, plus the reasoning in a comment.

> **@ the vault-migration owner** — this relaxes a guard your PR #75 set deliberately. Flagging it explicitly rather than slipping it through. If 300 was chosen for a reason not captured in the original comment, say so and we should revisit.

## Why

Two Teller headroom floors were written down independently, and they disagree on the same proposed change:

| Source | Floor |
|---|---:|
| Deposit-vault hardening plan, §5.3 (RG-SIZE-01) | 200 |
| `tests/test_vault_pointer_runtime_sizes.py`, from PR #75 | 300 |

The Section 13 Teller receipt-window guard measures **+81 bytes → 237 of headroom**. That **passes 200 and fails 300** — so the same change was simultaneously allowed and forbidden depending on which document you read. Whoever next proposes a Teller change would hit two contradictory rules with no basis to choose.

Owner reconciled: the hardening plan's 200 governs.

## What does not change

Teller is at **24,258 deployed, 318 bytes free**. That already cleared the old 300. No contract changes, no deployed-size change — only the policy threshold the test enforces.

## Context on the change this unblocks

The receipt-window guard (DV-10) is **not currently approved**. The owner took the no-change path on it, with claim-asset admission (callback-free tokens only) as the mitigation — see the operating-rules runbook in #79. This PR just removes the contradiction so a future proposal has a single stated rule.

Verified: `tests/test_vault_pointer_runtime_sizes.py` passes.

Branched from `6260726`; not chasing the `rh` tip during the active deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)