### PR TITLE
docs(rh): correct the stale RH-CHANGE-01 decision-gate row

### DIFF
--- a/docs/chains/rh/deposit-vault-hardening-wp0-evidence.md
+++ b/docs/chains/rh/deposit-vault-hardening-wp0-evidence.md
@@ -97,7 +97,7 @@ guard and is included in §5.3.
 | SP-PRICE-01 | Option A by default. Characterized; no production change needed for A. But see DV-14: option A's liveness claim does not hold for a reverting price source. |
 | GOV-WEIGHT-01 | **UNRESOLVED.** No autonomous default. |
 | RG-SIZE-01 | **RESOLVED by the owner 2026-08-08:** the 200-byte floor governs. See the disposition below. §6 E-2 shows Option A is feasible at a stated cost. |
-| RH-CHANGE-01 | **UNRESOLVED.** No row approved; no production source edited. |
+| RH-CHANGE-01 | **PARTIALLY RESOLVED — 3 of 12 gated rows.** The owner approved the DV-01/02/03 RipeGov least-privilege row, merged 2026-08-07 as `30cf436` (PR #78). The other 9 rows (DV-04/05/06/08/09/10/13/14/15) remain unapproved and no production source is edited for them. See the disposition below. |
 
 **Stop condition encountered at WP0:** GOV-WEIGHT-01, RG-SIZE-01 and
 RH-CHANGE-01 were all unresolved *at the time this evidence was recorded*, so no
@@ -117,6 +117,26 @@ exact owner waiver — is unchanged and still binding.
 Nothing about any deployed contract changed with this decision: Teller's measured
 headroom is 318 bytes, which cleared both floors already. The decision only
 governs what future Teller growth is admissible.
+
+#### RH-CHANGE-01 disposition — owner, 2026-08-07 (partial)
+
+**One row approved: DV-01/02/03, RipeGov least privilege.** All three call sites
+(`depositTokensWithLockDuration`, `adjustLock`, `releaseLock`) went from
+`assert addys._isValidRipeAddr(msg.sender)` to
+`assert msg.sender == addys._getTellerAddr()`. Merged as `30cf436` (PR #78) with
+RipeGov's own block in `config/contract-artifact-expectations.json` regenerated in
+the same change. Measured effect: runtime template 24,490 bytes, deployed 24,522
+with the +32 immutable, **EIP-170 headroom 45 → 54** — the only candidate row that
+*shrinks* RipeGov.
+
+**RipeGov must be redeployed.** Its runtime bytecode changed; this is not a
+source-only edit.
+
+**The remaining 9 rows are still unapproved** (DV-04, DV-05, DV-06, DV-08, DV-09,
+DV-10, DV-13, DV-14, DV-15) and no production source is edited for them, so §17
+continues to apply to each. Note that DV-10's candidate (M7c, §13) is now
+*admissible on size* following the RG-SIZE-01 disposition above, but admissibility
+is not approval — it still needs its own RH-CHANGE-01 row.
 
 ---
 


### PR DESCRIPTION
## Summary

The decision-gate table in `docs/chains/rh/deposit-vault-hardening-wp0-evidence.md` still read:

```
| RH-CHANGE-01 | **UNRESOLVED.** No row approved; no production source edited. |
```

Both halves are now false. **PR #78** approved the DV-01/02/03 RipeGov least-privilege row and merged it as `30cf436`, editing production source — all three call sites moved from `assert addys._isValidRipeAddr(msg.sender)` to `assert msg.sender == addys._getTellerAddr()`.

This is the same defect fixed one row above it for RG-SIZE-01 in PR #80: a decision live in the code but stale in the authority record. Left alone, the table asserts no production contract has been touched while a merged contract change sits in the tree.

## Recorded as PARTIALLY RESOLVED, not RESOLVED

RH-CHANGE-01 gates **12** rows; only **3** are approved:

| Rows | State |
|---|---|
| DV-01, DV-02, DV-03 | **approved**, merged `30cf436` |
| DV-04, DV-05, DV-06, DV-08, DV-09, DV-10, DV-13, DV-14, DV-15 | unapproved, §17 still applies |

Marking the row `RESOLVED` would trade one inaccuracy for another.

## Changes

- gate row → **PARTIALLY RESOLVED — 3 of 12**, citing `30cf436`
- new **RH-CHANGE-01 disposition** subsection under §1, beside RG-SIZE-01's: what was approved, the measured effect (template 24,490; deployed 24,522 with the +32 immutable; **EIP-170 headroom 45 → 54**), that **RipeGov must be redeployed** because its runtime bytecode changed, and which rows remain open
- notes that DV-10's candidate (M7c, §13) is now *admissible on size* after the RG-SIZE-01 ruling, but that admissibility is not approval — it still needs its own row

## What was deliberately left alone

Scoped statements elsewhere — "No production contract is edited by this branch" and the rev-2 delta table's "zero production contracts" — are accurate about the WP0 deliverable and unchanged. The WP0 stop-condition paragraph keeps its point-in-time framing rather than being rewritten.

Docs only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)