### PR TITLE
Make RH pull request gate lean

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,10 +2,14 @@ name: Python tests
 
 on:
   pull_request:
+    branches:
+      - rh
+  merge_group:
+    branches:
+      - rh
   push:
     branches:
       - master
-      - rh
   workflow_dispatch:
     inputs:
       lane:
@@ -32,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lane: ${{ fromJSON(github.event_name == 'workflow_dispatch' && format('["{0}"]', inputs.lane) || '["lean","comprehensive"]') }}
+        lane: ${{ fromJSON(github.event_name == 'workflow_dispatch' && format('["{0}"]', inputs.lane) || '["lean"]') }}
     env:
       # The runner context is not available in jobs.<id>.env — only inside
       # steps — so these use github.workspace, which is.
@@ -113,9 +117,26 @@ jobs:
           path: ${{ github.workspace }}/.ci/boa
           key: ${{ steps.boa-cache.outputs.cache-primary-key }}
 
+  rh-pr-gate:
+    name: rh-pr-gate
+    if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require successful lean lane
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [ "$TEST_RESULT" != "success" ]; then
+            echo "Lean test lane did not succeed: $TEST_RESULT"
+            exit 1
+          fi
+
   manifest-promotion-macos:
     name: Python 3.12.0 / manifest-promotion-macos
-    if: github.event_name != 'workflow_dispatch' || inputs.lane == 'comprehensive'
+    if: github.event_name == 'workflow_dispatch' && inputs.lane == 'comprehensive'
     runs-on: macos-latest
     timeout-minutes: 60
     env:

--- a/tests/test_python_workflow_health.py
+++ b/tests/test_python_workflow_health.py
@@ -24,12 +24,27 @@ def _step(job, name):
     return next(step for step in job["steps"] if step.get("name") == name)
 
 
-def test_python_workflow_uses_full_history_and_bounded_lane_timeouts():
+def test_python_workflow_routes_automatic_events_to_one_lean_lane():
     workflow = _workflow()
-    assert workflow["on"]["push"]["branches"] == ["master", "rh"]
-    assert "pull_request" in workflow["on"]
+    assert workflow["on"]["pull_request"]["branches"] == ["rh"]
+    assert workflow["on"]["merge_group"]["branches"] == ["rh"]
+    assert workflow["on"]["push"]["branches"] == ["master"]
+    assert workflow["permissions"] == {"contents": "read"}
+
+    dispatch_lane = workflow["on"]["workflow_dispatch"]["inputs"]["lane"]
+    assert dispatch_lane["default"] == "lean"
+    assert dispatch_lane["options"] == ["lean", "comprehensive"]
 
     test_job = workflow["jobs"]["test"]
+    lane_matrix = test_job["strategy"]["matrix"]["lane"]
+    assert "github.event_name == 'workflow_dispatch'" in lane_matrix
+    assert "inputs.lane" in lane_matrix
+    assert "'[\"lean\"]'" in lane_matrix
+    assert "lean\",\"comprehensive" not in lane_matrix
+
+
+def test_python_workflow_uses_full_history_and_bounded_lane_timeouts():
+    test_job = _workflow()["jobs"]["test"]
     checkout = _step(test_job, "Check out source")
     assert checkout["with"]["fetch-depth"] == "0"
     assert test_job["timeout-minutes"] == (
@@ -68,13 +83,29 @@ def test_python_workflow_cancels_superseded_pr_or_branch_runs():
     assert "head.sha" not in group
 
 
-def test_python_workflow_runs_manifest_promotion_on_macos():
+def test_python_workflow_exposes_stable_rh_pr_gate():
+    job = _workflow()["jobs"]["rh-pr-gate"]
+    assert job["name"] == "rh-pr-gate"
+    assert job["needs"] == ["test"]
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["timeout-minutes"] == "5"
+    assert "always()" in job["if"]
+    assert "github.event_name == 'pull_request'" in job["if"]
+    assert "github.event_name == 'merge_group'" in job["if"]
+
+    step = _step(job, "Require successful lean lane")
+    assert step["env"]["TEST_RESULT"] == "${{ needs.test.result }}"
+    assert 'if [ "$TEST_RESULT" != "success" ]' in step["run"]
+    assert "exit 1" in step["run"]
+
+
+def test_python_workflow_runs_manifest_promotion_only_for_manual_comprehensive():
     jobs = _workflow()["jobs"]
     job = jobs["manifest-promotion-macos"]
     assert job["runs-on"] == "macos-latest"
     assert job["timeout-minutes"] == "60"
     assert job["if"] == (
-        "github.event_name != 'workflow_dispatch' || "
+        "github.event_name == 'workflow_dispatch' && "
         "inputs.lane == 'comprehensive'"
     )
     checkout = _step(job, "Check out full source history")


### PR DESCRIPTION
## Summary

- route pull requests and merge groups targeting `rh` to one lean Linux lane
- stop the duplicate automatic run from pushes to `rh` and the long-lived `rh -> master` pull request
- retain a lean `master` push lane and explicit manual lean/comprehensive lanes
- run macOS manifest promotion only for a manual comprehensive invocation
- expose one stable `rh-pr-gate` check that rejects every upstream result except success

## Event behavior

| Event | Jobs |
| --- | --- |
| Pull request targeting `rh` | Linux lean, then `rh-pr-gate` |
| Merge group targeting `rh` | Linux lean, then `rh-pr-gate` |
| Push to `master` | Linux lean |
| Push to `rh` | No run |
| Manual lean | Linux lean |
| Manual comprehensive | Linux comprehensive plus macOS manifest promotion |
| Pull request targeting `master` | No run |

## Validation

- workflow parsed with the repository's PyYAML `BaseLoader`
- `tests/test_python_workflow_health.py`: 6 passed
- lean collect-only: 3,552 nodes
- comprehensive collect-only: 4,461 nodes
- `git diff --check`

The full suite was not rerun because this PR changes orchestration only and preserves both existing pytest commands unchanged.

## Scope boundaries

No production contracts, configuration, migrations, manifests, pytest markers, dependencies, checkout depth, cache policy, branch settings, or GitHub repository settings are changed here.
